### PR TITLE
Use trait methods instead of boxed callbacks for param parse/display

### DIFF
--- a/coupler-derive/src/params.rs
+++ b/coupler-derive/src/params.rs
@@ -276,6 +276,8 @@ pub fn expand_params(input: &DeriveInput) -> Result<TokenStream, Error> {
         }
     });
 
+    // parse_cases and display_cases
+
     Ok(quote! {
         impl #impl_generics ::coupler::params::Params for #ident #ty_generics #where_clause {
             fn params() -> ::std::vec::Vec<::coupler::params::ParamInfo> {

--- a/coupler-derive/src/params.rs
+++ b/coupler-derive/src/params.rs
@@ -212,40 +212,12 @@ pub fn expand_params(input: &DeriveInput) -> Result<TokenStream, Error> {
             quote! { <#ty as ::coupler::params::Encode>::steps() }
         };
 
-        let encode = gen_encode(field.field, &field.param, quote! { __value });
-        let parse = if let Some(parse) = &field.param.parse {
-            quote! {
-                match (#parse)(__str) {
-                    ::std::option::Option::Some(__value) => ::std::option::Option::Some(#encode),
-                    _ => ::std::option::Option::None,
-                }
-            }
-        } else {
-            quote! {
-                match <#ty as ::std::str::FromStr>::from_str(__str) {
-                    ::std::result::Result::Ok(__value) => ::std::option::Option::Some(#encode),
-                    _ => ::std::option::Option::None,
-                }
-            }
-        };
-
-        let decode = gen_decode(field.field, &field.param, quote! { __value });
-        let display = if let Some(display) = &field.param.display {
-            quote! { (#display)(#decode, __formatter) }
-        } else if let Some(format) = &field.param.format {
-            quote! { write!(__formatter, #format, #decode) }
-        } else {
-            quote! { write!(__formatter, "{}", #decode) }
-        };
-
         quote! {
             ::coupler::params::ParamInfo {
                 id: #id,
                 name: ::std::string::ToString::to_string(#name),
                 default: #default,
                 steps: #steps,
-                parse: ::std::boxed::Box::new(|__str| #parse),
-                display: ::std::boxed::Box::new(|__value, __formatter| #display),
             }
         }
     });
@@ -276,7 +248,52 @@ pub fn expand_params(input: &DeriveInput) -> Result<TokenStream, Error> {
         }
     });
 
-    // parse_cases and display_cases
+    let parse_cases = fields.iter().map(|field| {
+        let ty = &field.field.ty;
+        let id = &field.param.id;
+
+        let encode = gen_encode(field.field, &field.param, quote! { __value });
+        let parse = if let Some(parse) = &field.param.parse {
+            quote! {
+                match (#parse)(__text) {
+                    ::std::option::Option::Some(__value) => ::std::option::Option::Some(#encode),
+                    _ => ::std::option::Option::None,
+                }
+            }
+        } else {
+            quote! {
+                match <#ty as ::std::str::FromStr>::from_str(__text) {
+                    ::std::result::Result::Ok(__value) => ::std::option::Option::Some(#encode),
+                    _ => ::std::option::Option::None,
+                }
+            }
+        };
+
+        quote! {
+            #id => {
+                #parse
+            }
+        }
+    });
+
+    let display_cases = fields.iter().map(|field| {
+        let id = &field.param.id;
+
+        let decode = gen_decode(field.field, &field.param, quote! { __value });
+        let display = if let Some(display) = &field.param.display {
+            quote! { (#display)(#decode, __fmt) }
+        } else if let Some(format) = &field.param.format {
+            quote! { write!(__fmt, #format, #decode) }
+        } else {
+            quote! { write!(__fmt, "{}", #decode) }
+        };
+
+        quote! {
+            #id => {
+                #display
+            }
+        }
+    });
 
     Ok(quote! {
         impl #impl_generics ::coupler::params::Params for #ident #ty_generics #where_clause {
@@ -299,6 +316,25 @@ pub fn expand_params(input: &DeriveInput) -> Result<TokenStream, Error> {
                 match __id {
                     #(#get_cases)*
                     _ => 0.0,
+                }
+            }
+
+            fn parse_param(&self, __id: ::coupler::params::ParamId, __text: &::std::primitive::str) -> ::std::option::Option<::coupler::params::ParamValue> {
+                match __id {
+                    #(#parse_cases)*
+                    _ => ::std::option::Option::None
+                }
+            }
+
+            fn display_param(
+                &self,
+                __id: ::coupler::params::ParamId,
+                __value: ::coupler::params::ParamValue,
+                __fmt: &mut ::std::fmt::Formatter,
+            ) -> ::std::result::Result<(), ::std::fmt::Error> {
+                match __id {
+                    #(#display_cases)*
+                    _ => Ok(())
                 }
             }
         }

--- a/examples/gain/src/lib.rs
+++ b/examples/gain/src/lib.rs
@@ -1,4 +1,5 @@
 use std::cell::RefCell;
+use std::fmt::{self, Formatter};
 use std::io::{self, Read, Write};
 use std::rc::Rc;
 
@@ -13,8 +14,8 @@ use coupler::{buffers::*, bus::*, engine::*, events::*, host::*, params::*, plug
 use flicker::Renderer;
 
 use portlight::{
-    App, AppMode, AppOptions, Bitmap, Cursor, MouseButton, Point, RawWindow, Response, Result,
-    Window, WindowContext, WindowOptions,
+    App, AppMode, AppOptions, Bitmap, Cursor, MouseButton, Point, RawWindow, Response, Window,
+    WindowContext, WindowOptions,
 };
 
 #[derive(Params, Serialize, Deserialize, Clone)]
@@ -73,6 +74,19 @@ impl Plugin for Gain {
 
     fn get_param(&self, id: ParamId) -> ParamValue {
         self.params.get_param(id)
+    }
+
+    fn parse_param(&self, id: ParamId, text: &str) -> Option<ParamValue> {
+        self.params.parse_param(id, text)
+    }
+
+    fn display_param(
+        &self,
+        id: ParamId,
+        value: ParamValue,
+        fmt: &mut Formatter,
+    ) -> Result<(), fmt::Error> {
+        self.params.display_param(id, value, fmt)
     }
 
     fn save(&self, output: &mut impl Write) -> io::Result<()> {
@@ -285,7 +299,11 @@ pub struct GainView {
 }
 
 impl GainView {
-    fn open(host: ViewHost, parent: &ParentWindow, params: &GainParams) -> Result<GainView> {
+    fn open(
+        host: ViewHost,
+        parent: &ParentWindow,
+        params: &GainParams,
+    ) -> portlight::Result<GainView> {
         let app = AppOptions::new().mode(AppMode::Guest).build()?;
 
         let mut options = WindowOptions::new();

--- a/src/format/clap/tests.rs
+++ b/src/format/clap/tests.rs
@@ -1,4 +1,5 @@
 use std::ffi::{c_char, CStr};
+use std::fmt::{self, Formatter};
 use std::io::{self, Read, Write};
 
 use crate::buffers::Buffers;
@@ -47,6 +48,17 @@ impl Plugin for TestPlugin {
     fn set_param(&mut self, _id: ParamId, _value: ParamValue) {}
     fn get_param(&self, _id: ParamId) -> ParamValue {
         0.0
+    }
+    fn parse_param(&self, _id: ParamId, _text: &str) -> Option<ParamValue> {
+        None
+    }
+    fn display_param(
+        &self,
+        _id: ParamId,
+        _value: ParamValue,
+        _fmt: &mut Formatter,
+    ) -> Result<(), fmt::Error> {
+        Ok(())
     }
     fn save(&self, _output: &mut impl Write) -> io::Result<()> {
         Ok(())

--- a/src/format/vst3/tests.rs
+++ b/src/format/vst3/tests.rs
@@ -1,5 +1,6 @@
 use std::error::Error;
 use std::ffi::CStr;
+use std::fmt::{self, Formatter};
 use std::io::{self, Read, Write};
 use std::{ptr, slice};
 
@@ -54,6 +55,17 @@ impl Plugin for TestPlugin {
     fn set_param(&mut self, _id: ParamId, _value: ParamValue) {}
     fn get_param(&self, _id: ParamId) -> ParamValue {
         0.0
+    }
+    fn parse_param(&self, _id: ParamId, _text: &str) -> Option<ParamValue> {
+        None
+    }
+    fn display_param(
+        &self,
+        _id: ParamId,
+        _value: ParamValue,
+        _fmt: &mut Formatter,
+    ) -> Result<(), fmt::Error> {
+        Ok(())
     }
     fn save(&self, _output: &mut impl Write) -> io::Result<()> {
         Ok(())

--- a/src/params.rs
+++ b/src/params.rs
@@ -11,22 +11,24 @@ pub use range::{Encode, Log, Range};
 pub type ParamId = u32;
 pub type ParamValue = f64;
 
-pub type ParseFn = dyn Fn(&str) -> Option<ParamValue> + Send + Sync;
-pub type DisplayFn = dyn Fn(ParamValue, &mut Formatter) -> Result<(), fmt::Error> + Send + Sync;
-
 pub struct ParamInfo {
     pub id: ParamId,
     pub name: String,
     pub default: ParamValue,
     pub steps: Option<u32>,
-    pub parse: Box<ParseFn>,
-    pub display: Box<DisplayFn>,
 }
 
 pub trait Params {
     fn params() -> Vec<ParamInfo>;
     fn set_param(&mut self, id: ParamId, value: ParamValue);
     fn get_param(&self, id: ParamId) -> ParamValue;
+    fn parse_param(&self, id: ParamId, text: &str) -> Option<ParamValue>;
+    fn display_param(
+        &self,
+        id: ParamId,
+        value: ParamValue,
+        fmt: &mut Formatter,
+    ) -> Result<(), fmt::Error>;
 }
 
 pub trait Enum: Encode + FromStr + Display {}

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,3 +1,4 @@
+use std::fmt::{self, Formatter};
 use std::io::{self, Read, Write};
 
 use crate::bus::{BusInfo, Layout};
@@ -43,6 +44,13 @@ pub trait Plugin: Send + Sized + 'static {
     fn new(host: Host) -> Self;
     fn set_param(&mut self, id: ParamId, value: ParamValue);
     fn get_param(&self, id: ParamId) -> ParamValue;
+    fn parse_param(&self, id: ParamId, text: &str) -> Option<ParamValue>;
+    fn display_param(
+        &self,
+        id: ParamId,
+        value: ParamValue,
+        fmt: &mut Formatter,
+    ) -> Result<(), fmt::Error>;
     fn save(&self, output: &mut impl Write) -> io::Result<()>;
     fn load(&mut self, input: &mut impl Read) -> io::Result<()>;
     fn engine(&mut self, config: Config) -> Self::Engine;

--- a/src/util.rs
+++ b/src/util.rs
@@ -3,7 +3,8 @@ use std::fmt::{self, Display, Formatter};
 use std::os::raw::c_char;
 use std::slice;
 
-use crate::params::{ParamInfo, ParamValue};
+use crate::params::{ParamId, ParamValue};
+use crate::plugin::Plugin;
 
 pub fn copy_cstring(src: &str, dst: &mut [c_char]) {
     let c_string = CString::new(src).unwrap_or_else(|_| CString::default());
@@ -32,10 +33,23 @@ pub unsafe fn slice_from_raw_parts_checked<'a, T>(ptr: *const T, len: usize) -> 
     }
 }
 
-pub struct DisplayParam<'a>(pub &'a ParamInfo, pub ParamValue);
+pub struct DisplayParam<'a, P> {
+    plugin: &'a P,
+    id: ParamId,
+    value: ParamValue,
+}
 
-impl<'a> Display for DisplayParam<'a> {
+impl<'a, P> DisplayParam<'a, P> {
+    pub fn new(plugin: &'a P, id: ParamId, value: ParamValue) -> Self {
+        DisplayParam { plugin, id, value }
+    }
+}
+
+impl<'a, P> Display for DisplayParam<'a, P>
+where
+    P: Plugin,
+{
     fn fmt(&self, f: &mut Formatter) -> Result<(), fmt::Error> {
-        (self.0.display)(self.1, f)
+        self.plugin.display_param(self.id, self.value, f)
     }
 }


### PR DESCRIPTION
Parameter string conversions are currently performed using a pair of boxed closures provided via the `ParamInfo` struct. Remove the boxed closures in favor of a pair of methods on the `Plugin` and `Params` traits.