### PR TITLE
update all crates to 2024 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "coupler"
 version = "0.1.0"
 authors = ["Micah Johnston <micah@photophore.systems>"]
-edition = "2021"
+edition = "2024"
 license = "MIT OR Apache-2.0"
 publish = false
 

--- a/cargo-coupler/Cargo.toml
+++ b/cargo-coupler/Cargo.toml
@@ -2,7 +2,7 @@
 name = "cargo-coupler"
 version = "0.1.0"
 authors = ["Micah Johnston <micah@photophore.systems>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [dependencies]

--- a/coupler-derive/Cargo.toml
+++ b/coupler-derive/Cargo.toml
@@ -2,7 +2,7 @@
 name = "coupler-derive"
 version = "0.1.0"
 authors = ["Micah Johnston <micah@photophore.systems>"]
-edition = "2021"
+edition = "2024"
 
 [lib]
 proc-macro = true

--- a/examples/gain-gui/Cargo.toml
+++ b/examples/gain-gui/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gain-gui"
 version = "0.1.0"
 authors = ["Micah Johnston <micah@photophore.systems>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [dependencies]

--- a/examples/gain-gui/format/clap/Cargo.toml
+++ b/examples/gain-gui/format/clap/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gain-gui-clap"
 version = "0.1.0"
 authors = ["Micah Johnston <micah@photophore.systems>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [package.metadata.coupler]

--- a/examples/gain-gui/format/vst3/Cargo.toml
+++ b/examples/gain-gui/format/vst3/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gain-gui-vst3"
 version = "0.1.0"
 authors = ["Micah Johnston <micah@photophore.systems>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [package.metadata.coupler]

--- a/examples/gain/Cargo.toml
+++ b/examples/gain/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gain"
 version = "0.1.0"
 authors = ["Micah Johnston <micah@photophore.systems>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [dependencies]

--- a/examples/gain/format/clap/Cargo.toml
+++ b/examples/gain/format/clap/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gain-clap"
 version = "0.1.0"
 authors = ["Micah Johnston <micah@photophore.systems>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [package.metadata.coupler]

--- a/examples/gain/format/vst3/Cargo.toml
+++ b/examples/gain/format/vst3/Cargo.toml
@@ -2,7 +2,7 @@
 name = "gain-vst3"
 version = "0.1.0"
 authors = ["Micah Johnston <micah@photophore.systems>"]
-edition = "2021"
+edition = "2024"
 publish = false
 
 [package.metadata.coupler]

--- a/src/buffers.rs
+++ b/src/buffers.rs
@@ -28,8 +28,12 @@ impl<'a, 'b> AnyBuffer<'a, 'b> {
         len: usize,
     ) -> AnyBuffer<'a, 'b> {
         match buffer_type {
-            BufferType::Const => AnyBuffer::Const(Buffer::from_raw_parts(ptrs, offset, len)),
-            BufferType::Mut => AnyBuffer::Mut(BufferMut::from_raw_parts(ptrs, offset, len)),
+            BufferType::Const => {
+                AnyBuffer::Const(unsafe { Buffer::from_raw_parts(ptrs, offset, len) })
+            }
+            BufferType::Mut => {
+                AnyBuffer::Mut(unsafe { BufferMut::from_raw_parts(ptrs, offset, len) })
+            }
         }
     }
 }
@@ -193,8 +197,8 @@ impl<'a, 'b> AnySample<'a, 'b> {
         offset: isize,
     ) -> AnySample<'a, 'b> {
         match buffer_type {
-            BufferType::Const => AnySample::Const(Sample::from_raw_parts(ptrs, offset)),
-            BufferType::Mut => AnySample::Mut(SampleMut::from_raw_parts(ptrs, offset)),
+            BufferType::Const => AnySample::Const(unsafe { Sample::from_raw_parts(ptrs, offset) }),
+            BufferType::Mut => AnySample::Mut(unsafe { SampleMut::from_raw_parts(ptrs, offset) }),
         }
     }
 }

--- a/src/format/clap/factory.rs
+++ b/src/format/clap/factory.rs
@@ -52,7 +52,9 @@ impl<P: Plugin + ClapPlugin> Factory<P> {
         const EMPTY: &CStr = c"";
         const FEATURES: &[*const c_char] = &[ptr::null()];
 
-        *self.state.get() = Some(FactoryState {
+        let state = unsafe { &mut *self.state.get() };
+
+        *state = Some(FactoryState {
             descriptor: clap_plugin_descriptor {
                 clap_version: CLAP_VERSION,
                 id,
@@ -71,17 +73,19 @@ impl<P: Plugin + ClapPlugin> Factory<P> {
     }
 
     pub unsafe fn deinit(&self) {
-        if let Some(state) = (*self.state.get()).take() {
-            drop(CString::from_raw(state.descriptor.id as *mut c_char));
-            drop(CString::from_raw(state.descriptor.name as *mut c_char));
-            drop(CString::from_raw(state.descriptor.vendor as *mut c_char));
-            drop(CString::from_raw(state.descriptor.url as *mut c_char));
-            drop(CString::from_raw(state.descriptor.version as *mut c_char));
+        let state = unsafe { &mut *self.state.get() };
+
+        if let Some(state) = state.take() {
+            drop(unsafe { CString::from_raw(state.descriptor.id as *mut c_char) });
+            drop(unsafe { CString::from_raw(state.descriptor.name as *mut c_char) });
+            drop(unsafe { CString::from_raw(state.descriptor.vendor as *mut c_char) });
+            drop(unsafe { CString::from_raw(state.descriptor.url as *mut c_char) });
+            drop(unsafe { CString::from_raw(state.descriptor.version as *mut c_char) });
         }
     }
 
     pub unsafe fn get(&self, factory_id: *const c_char) -> *const c_void {
-        if CStr::from_ptr(factory_id) == CLAP_PLUGIN_FACTORY_ID {
+        if unsafe { CStr::from_ptr(factory_id) } == CLAP_PLUGIN_FACTORY_ID {
             return self as *const Self as *const c_void;
         }
 
@@ -96,10 +100,12 @@ impl<P: Plugin + ClapPlugin> Factory<P> {
         factory: *const clap_plugin_factory,
         index: u32,
     ) -> *const clap_plugin_descriptor {
-        let factory = &*(factory as *const Self);
+        let factory = unsafe { &*(factory as *const Self) };
 
         if index == 0 {
-            if let Some(state) = &*factory.state.get() {
+            let state = unsafe { &*factory.state.get() };
+
+            if let Some(state) = state {
                 return &state.descriptor;
             }
         }
@@ -112,10 +118,13 @@ impl<P: Plugin + ClapPlugin> Factory<P> {
         host: *const clap_host,
         plugin_id: *const c_char,
     ) -> *const clap_plugin {
-        let factory = &*(factory as *const Self);
+        let factory = unsafe { &*(factory as *const Self) };
+        let state = unsafe { &*factory.state.get() };
 
-        if let Some(state) = &*factory.state.get() {
-            if CStr::from_ptr(plugin_id) == CStr::from_ptr(state.descriptor.id) {
+        if let Some(state) = state {
+            if unsafe { CStr::from_ptr(plugin_id) }
+                == unsafe { CStr::from_ptr(state.descriptor.id) }
+            {
                 let instance = Box::new(Instance::<P>::new(&state.descriptor, host));
                 return Box::into_raw(instance) as *const clap_plugin;
             }

--- a/src/format/clap/gui.rs
+++ b/src/format/clap/gui.rs
@@ -83,7 +83,8 @@ impl<P: Plugin> Instance<P> {
             return false;
         }
 
-        CStr::from_ptr(api) == Self::API
+        let api = unsafe { CStr::from_ptr(api) };
+        api == Self::API
     }
 
     unsafe extern "C" fn gui_get_preferred_api(
@@ -91,8 +92,10 @@ impl<P: Plugin> Instance<P> {
         api: *mut *const c_char,
         is_floating: *mut bool,
     ) -> bool {
+        let is_floating = unsafe { &mut *is_floating };
         *is_floating = false;
 
+        let api = unsafe { &mut *api };
         *api = Self::API.as_ptr();
 
         true
@@ -103,7 +106,7 @@ impl<P: Plugin> Instance<P> {
         api: *const c_char,
         is_floating: bool,
     ) -> bool {
-        if !Self::gui_is_api_supported(plugin, api, is_floating) {
+        if !unsafe { Self::gui_is_api_supported(plugin, api, is_floating) } {
             return false;
         }
 
@@ -111,8 +114,8 @@ impl<P: Plugin> Instance<P> {
     }
 
     unsafe extern "C" fn gui_destroy(plugin: *const clap_plugin) {
-        let instance = &*(plugin as *const Self);
-        let main_thread_state = &mut *instance.main_thread_state.get();
+        let instance = unsafe { &*(plugin as *const Self) };
+        let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
 
         main_thread_state.view = None;
     }
@@ -126,13 +129,16 @@ impl<P: Plugin> Instance<P> {
         width: *mut u32,
         height: *mut u32,
     ) -> bool {
-        let instance = &*(plugin as *const Self);
-        let main_thread_state = &mut *instance.main_thread_state.get();
+        let instance = unsafe { &*(plugin as *const Self) };
+        let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
 
         if let Some(view) = &main_thread_state.view {
             let size = view.size();
 
+            let width = unsafe { &mut *width };
             *width = size.width.round() as u32;
+
+            let height = unsafe { &mut *height };
             *height = size.height.round() as u32;
 
             return true;
@@ -172,23 +178,23 @@ impl<P: Plugin> Instance<P> {
         plugin: *const clap_plugin,
         window: *const clap_window,
     ) -> bool {
-        let window = &*window;
+        let window = unsafe { &*window };
 
-        if CStr::from_ptr(window.api) != Self::API {
+        if unsafe { CStr::from_ptr(window.api) } != Self::API {
             return false;
         }
 
         #[cfg(target_os = "windows")]
-        let raw_parent = { RawParent::Win32(window.specific.win32) };
+        let raw_parent = { RawParent::Win32(unsafe { window.specific.win32 }) };
 
         #[cfg(target_os = "macos")]
-        let raw_parent = { RawParent::Cocoa(window.specific.cocoa) };
+        let raw_parent = { RawParent::Cocoa(unsafe { window.specific.cocoa }) };
 
         #[cfg(target_os = "linux")]
-        let raw_parent = { RawParent::X11(window.specific.x11) };
+        let raw_parent = { RawParent::X11(unsafe { window.specific.x11 }) };
 
-        let instance = &*(plugin as *const Self);
-        let main_thread_state = &mut *instance.main_thread_state.get();
+        let instance = unsafe { &*(plugin as *const Self) };
+        let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
 
         let host = ViewHost::from_inner(Rc::new(ClapViewHost {
             host: instance.host,
@@ -196,7 +202,7 @@ impl<P: Plugin> Instance<P> {
             param_map: Arc::clone(&instance.param_map),
             param_gestures: Arc::clone(&instance.param_gestures),
         }));
-        let parent = ParentWindow::from_raw(raw_parent);
+        let parent = unsafe { ParentWindow::from_raw(raw_parent) };
         let view = main_thread_state.plugin.view(host, &parent);
         main_thread_state.view = Some(view);
 

--- a/src/format/clap/instance.rs
+++ b/src/format/clap/instance.rs
@@ -185,14 +185,14 @@ impl<P: Plugin> Instance<P> {
     ) {
         let mut params_changed = false;
 
-        let size = (*in_events).size.unwrap()(in_events);
+        let size = unsafe { (*in_events).size.unwrap()(in_events) };
         for i in 0..size {
-            let event = (*in_events).get.unwrap()(in_events, i);
+            let event = unsafe { (*in_events).get.unwrap()(in_events, i) };
 
-            if (*event).space_id == CLAP_CORE_EVENT_SPACE_ID
-                && (*event).type_ == CLAP_EVENT_PARAM_VALUE
+            if unsafe { (*event).space_id } == CLAP_CORE_EVENT_SPACE_ID
+                && unsafe { (*event).type_ } == CLAP_EVENT_PARAM_VALUE
             {
-                let event = &*(event as *const clap_event_param_value);
+                let event = unsafe { &*(event as *const clap_event_param_value) };
 
                 if let Some(&index) = self.param_map.get(&event.param_id) {
                     let value = map_param_in(&self.params[index], event.value);
@@ -213,7 +213,7 @@ impl<P: Plugin> Instance<P> {
         }
 
         if params_changed {
-            (*self.host).request_callback.unwrap()(self.host);
+            unsafe { (*self.host).request_callback.unwrap()(self.host) };
         }
     }
 
@@ -239,7 +239,7 @@ impl<P: Plugin> Instance<P> {
                 self.plugin_params.set(update.index, value);
             }
 
-            self.send_gesture_events(&update, out_events, time);
+            unsafe { self.send_gesture_events(&update, out_events, time) };
         }
     }
 
@@ -263,10 +263,12 @@ impl<P: Plugin> Instance<P> {
                 param_id: param.id,
             };
 
-            (*out_events).try_push.unwrap()(
-                out_events,
-                &event as *const clap_event_param_gesture as *const clap_event_header,
-            );
+            unsafe {
+                (*out_events).try_push.unwrap()(
+                    out_events,
+                    &event as *const clap_event_param_gesture as *const clap_event_header,
+                )
+            };
         }
 
         if let Some(value) = update.set_value {
@@ -287,10 +289,12 @@ impl<P: Plugin> Instance<P> {
                 value: map_param_out(param, value),
             };
 
-            (*out_events).try_push.unwrap()(
-                out_events,
-                &event as *const clap_event_param_value as *const clap_event_header,
-            );
+            unsafe {
+                (*out_events).try_push.unwrap()(
+                    out_events,
+                    &event as *const clap_event_param_value as *const clap_event_header,
+                )
+            };
         }
 
         if update.end_gesture {
@@ -305,28 +309,31 @@ impl<P: Plugin> Instance<P> {
                 param_id: param.id,
             };
 
-            (*out_events).try_push.unwrap()(
-                out_events,
-                &event as *const clap_event_param_gesture as *const clap_event_header,
-            );
+            unsafe {
+                (*out_events).try_push.unwrap()(
+                    out_events,
+                    &event as *const clap_event_param_gesture as *const clap_event_header,
+                )
+            };
         }
     }
 }
 
 impl<P: Plugin> Instance<P> {
     unsafe extern "C" fn init(plugin: *const clap_plugin) -> bool {
-        let instance = &*(plugin as *const Self);
-        let main_thread_state = &mut *instance.main_thread_state.get();
+        let instance = unsafe { &*(plugin as *const Self) };
+        let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
 
-        let host_params =
-            (*instance.host).get_extension.unwrap()(instance.host, CLAP_EXT_PARAMS.as_ptr());
+        let host_params = unsafe {
+            (*instance.host).get_extension.unwrap()(instance.host, CLAP_EXT_PARAMS.as_ptr())
+        };
         main_thread_state.host_params = NonNull::new(host_params as *mut clap_host_params);
 
         true
     }
 
     unsafe extern "C" fn destroy(plugin: *const clap_plugin) {
-        drop(Box::from_raw(plugin as *mut Self));
+        drop(unsafe { Box::from_raw(plugin as *mut Self) });
     }
 
     unsafe extern "C" fn activate(
@@ -335,9 +342,9 @@ impl<P: Plugin> Instance<P> {
         _min_frames_count: u32,
         max_frames_count: u32,
     ) -> bool {
-        let instance = &*(plugin as *const Self);
-        let main_thread_state = &mut *instance.main_thread_state.get();
-        let process_state = &mut *instance.process_state.get();
+        let instance = unsafe { &*(plugin as *const Self) };
+        let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
+        let process_state = unsafe { &mut *instance.process_state.get() };
 
         let layout = &instance.layouts[main_thread_state.layout_index];
 
@@ -377,9 +384,9 @@ impl<P: Plugin> Instance<P> {
     }
 
     unsafe extern "C" fn deactivate(plugin: *const clap_plugin) {
-        let instance = &*(plugin as *const Self);
-        let main_thread_state = &mut *instance.main_thread_state.get();
-        let process_state = &mut *instance.process_state.get();
+        let instance = unsafe { &*(plugin as *const Self) };
+        let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
+        let process_state = unsafe { &mut *instance.process_state.get() };
 
         // Apply any remaining engine -> plugin parameter changes. There won't be any more until
         // the next call to `activate`.
@@ -395,8 +402,8 @@ impl<P: Plugin> Instance<P> {
     unsafe extern "C" fn stop_processing(_plugin: *const clap_plugin) {}
 
     unsafe extern "C" fn reset(plugin: *const clap_plugin) {
-        let instance = &*(plugin as *const Self);
-        let process_state = &mut *instance.process_state.get();
+        let instance = unsafe { &*(plugin as *const Self) };
+        let process_state = unsafe { &mut *instance.process_state.get() };
 
         if let Some(engine) = &mut process_state.engine {
             // Flush plugin -> engine parameter changes
@@ -415,14 +422,14 @@ impl<P: Plugin> Instance<P> {
         plugin: *const clap_plugin,
         process: *const clap_process,
     ) -> clap_process_status {
-        let instance = &*(plugin as *const Self);
-        let process_state = &mut *instance.process_state.get();
+        let instance = unsafe { &*(plugin as *const Self) };
+        let process_state = unsafe { &mut *instance.process_state.get() };
 
         let Some(engine) = &mut process_state.engine else {
             return CLAP_PROCESS_ERROR;
         };
 
-        let process = &*process;
+        let process = unsafe { &*process };
 
         let len = process.frames_count as usize;
 
@@ -434,8 +441,8 @@ impl<P: Plugin> Instance<P> {
             return CLAP_PROCESS_ERROR;
         }
 
-        let inputs = slice_from_raw_parts_checked(process.audio_inputs, input_count);
-        let outputs = slice_from_raw_parts_checked(process.audio_outputs, output_count);
+        let inputs = unsafe { slice_from_raw_parts_checked(process.audio_inputs, input_count) };
+        let outputs = unsafe { slice_from_raw_parts_checked(process.audio_outputs, output_count) };
 
         for (&bus_index, output) in zip(&instance.output_bus_map, outputs) {
             let data = &process_state.buffer_data[bus_index];
@@ -445,8 +452,9 @@ impl<P: Plugin> Instance<P> {
                 return CLAP_PROCESS_ERROR;
             }
 
-            let channels =
-                slice_from_raw_parts_checked(output.data32 as *const *mut f32, channel_count);
+            let channels = unsafe {
+                slice_from_raw_parts_checked(output.data32 as *const *mut f32, channel_count)
+            };
             process_state.buffer_ptrs[data.start..data.end].copy_from_slice(channels);
         }
 
@@ -459,8 +467,9 @@ impl<P: Plugin> Instance<P> {
                 return CLAP_PROCESS_ERROR;
             }
 
-            let channels =
-                slice_from_raw_parts_checked(input.data32 as *const *mut f32, channel_count);
+            let channels = unsafe {
+                slice_from_raw_parts_checked(input.data32 as *const *mut f32, channel_count)
+            };
             let ptrs = &mut process_state.buffer_ptrs[data.start..data.end];
 
             match bus_info.dir {
@@ -470,8 +479,8 @@ impl<P: Plugin> Instance<P> {
                 BusDir::InOut => {
                     for (&src, &mut dst) in zip(channels, ptrs) {
                         if src != dst {
-                            let src = slice::from_raw_parts(src, len);
-                            let dst = slice::from_raw_parts_mut(dst, len);
+                            let src = unsafe { slice::from_raw_parts(src, len) };
+                            let dst = unsafe { slice::from_raw_parts_mut(dst, len) };
                             dst.copy_from_slice(src);
                         }
                     }
@@ -482,25 +491,27 @@ impl<P: Plugin> Instance<P> {
 
         process_state.events.clear();
         instance.sync_engine(&mut process_state.events);
-        instance.process_param_events(process.in_events, &mut process_state.events);
+        unsafe { instance.process_param_events(process.in_events, &mut process_state.events) };
 
         let last_sample = process.frames_count.saturating_sub(1);
-        instance.process_gestures(
-            &mut process_state.gesture_states,
-            &mut process_state.events,
-            process.out_events,
-            last_sample,
-        );
+        unsafe {
+            instance.process_gestures(
+                &mut process_state.gesture_states,
+                &mut process_state.events,
+                process.out_events,
+                last_sample,
+            )
+        };
 
-        engine.process(
+        let buffers = unsafe {
             Buffers::from_raw_parts(
                 &process_state.buffer_data,
                 &process_state.buffer_ptrs,
                 0,
                 len,
-            ),
-            Events::new(&process_state.events),
-        );
+            )
+        };
+        engine.process(buffers, Events::new(&process_state.events));
 
         CLAP_PROCESS_CONTINUE
     }
@@ -509,7 +520,7 @@ impl<P: Plugin> Instance<P> {
         plugin: *const clap_plugin,
         id: *const c_char,
     ) -> *const c_void {
-        let id = CStr::from_ptr(id);
+        let id = unsafe { CStr::from_ptr(id) };
 
         if id == CLAP_EXT_AUDIO_PORTS {
             return &Self::AUDIO_PORTS as *const _ as *const c_void;
@@ -528,7 +539,7 @@ impl<P: Plugin> Instance<P> {
         }
 
         if id == CLAP_EXT_GUI {
-            let instance = &*(plugin as *const Self);
+            let instance = unsafe { &*(plugin as *const Self) };
             if instance.has_view {
                 return &Self::GUI as *const _ as *const c_void;
             }
@@ -538,8 +549,8 @@ impl<P: Plugin> Instance<P> {
     }
 
     unsafe extern "C" fn on_main_thread(plugin: *const clap_plugin) {
-        let instance = &*(plugin as *const Self);
-        let main_thread_state = &mut *instance.main_thread_state.get();
+        let instance = unsafe { &*(plugin as *const Self) };
+        let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
 
         instance.sync_plugin(main_thread_state);
     }
@@ -552,7 +563,7 @@ impl<P: Plugin> Instance<P> {
     };
 
     unsafe extern "C" fn audio_ports_count(plugin: *const clap_plugin, is_input: bool) -> u32 {
-        let instance = &*(plugin as *const Self);
+        let instance = unsafe { &*(plugin as *const Self) };
 
         if is_input {
             instance.input_bus_map.len() as u32
@@ -567,8 +578,8 @@ impl<P: Plugin> Instance<P> {
         is_input: bool,
         info: *mut clap_audio_port_info,
     ) -> bool {
-        let instance = &*(plugin as *const Self);
-        let main_thread_state = &mut *instance.main_thread_state.get();
+        let instance = unsafe { &*(plugin as *const Self) };
+        let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
 
         let bus_index = if is_input {
             instance.input_bus_map.get(index as usize)
@@ -583,7 +594,7 @@ impl<P: Plugin> Instance<P> {
             let format = layout.formats.get(bus_index);
 
             if let (Some(bus_info), Some(format)) = (bus_info, format) {
-                let port_info = &mut *info;
+                let port_info = unsafe { &mut *info };
 
                 port_info.id = index;
                 copy_cstring(&bus_info.name, &mut port_info.name);
@@ -623,7 +634,7 @@ impl<P: Plugin> Instance<P> {
     };
 
     unsafe extern "C" fn audio_ports_config_count(plugin: *const clap_plugin) -> u32 {
-        let instance = &*(plugin as *const Self);
+        let instance = unsafe { &*(plugin as *const Self) };
 
         instance.layouts.len() as u32
     }
@@ -633,10 +644,10 @@ impl<P: Plugin> Instance<P> {
         index: u32,
         config: *mut clap_audio_ports_config,
     ) -> bool {
-        let instance = &*(plugin as *const Self);
+        let instance = unsafe { &*(plugin as *const Self) };
 
         if let Some(layout) = instance.layouts.get(index as usize) {
-            let config = &mut *config;
+            let config = unsafe { &mut *config };
 
             config.id = index;
             copy_cstring("", &mut config.name);
@@ -677,8 +688,8 @@ impl<P: Plugin> Instance<P> {
         plugin: *const clap_plugin,
         config_id: clap_id,
     ) -> bool {
-        let instance = &*(plugin as *const Self);
-        let main_thread_state = &mut *instance.main_thread_state.get();
+        let instance = unsafe { &*(plugin as *const Self) };
+        let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
 
         if instance.layouts.get(config_id as usize).is_some() {
             main_thread_state.layout_index = config_id as usize;
@@ -700,7 +711,7 @@ impl<P: Plugin> Instance<P> {
     };
 
     unsafe extern "C" fn params_count(plugin: *const clap_plugin) -> u32 {
-        let instance = &*(plugin as *const Self);
+        let instance = unsafe { &*(plugin as *const Self) };
 
         instance.params.len() as u32
     }
@@ -710,10 +721,10 @@ impl<P: Plugin> Instance<P> {
         param_index: u32,
         param_info: *mut clap_param_info,
     ) -> bool {
-        let instance = &*(plugin as *const Self);
+        let instance = unsafe { &*(plugin as *const Self) };
 
         if let Some(param) = instance.params.get(param_index as usize) {
-            let param_info = &mut *param_info;
+            let param_info = unsafe { &mut *param_info };
 
             param_info.id = param.id;
             param_info.flags = CLAP_PARAM_IS_AUTOMATABLE;
@@ -741,13 +752,14 @@ impl<P: Plugin> Instance<P> {
         param_id: clap_id,
         value: *mut f64,
     ) -> bool {
-        let instance = &*(plugin as *const Self);
-        let main_thread_state = &mut *instance.main_thread_state.get();
+        let instance = unsafe { &*(plugin as *const Self) };
+        let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
 
         if let Some(&index) = instance.param_map.get(&param_id) {
             instance.sync_plugin(main_thread_state);
 
             let param = &instance.params[index];
+            let value = unsafe { &mut *value };
             *value = map_param_out(param, main_thread_state.plugin.get_param(param_id));
             return true;
         }
@@ -762,8 +774,8 @@ impl<P: Plugin> Instance<P> {
         display: *mut c_char,
         size: u32,
     ) -> bool {
-        let instance = &*(plugin as *const Self);
-        let main_thread_state = &mut *instance.main_thread_state.get();
+        let instance = unsafe { &*(plugin as *const Self) };
+        let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
 
         if let Some(&index) = instance.param_map.get(&param_id) {
             let param = &instance.params[index];
@@ -777,7 +789,7 @@ impl<P: Plugin> Instance<P> {
                 )
             );
 
-            let dst = slice::from_raw_parts_mut(display, size as usize);
+            let dst = unsafe { slice::from_raw_parts_mut(display, size as usize) };
             copy_cstring(&text, dst);
 
             return true;
@@ -792,13 +804,14 @@ impl<P: Plugin> Instance<P> {
         display: *const c_char,
         value: *mut f64,
     ) -> bool {
-        let instance = &*(plugin as *const Self);
-        let main_thread_state = &mut *instance.main_thread_state.get();
+        let instance = unsafe { &*(plugin as *const Self) };
+        let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
 
         if let Some(&index) = instance.param_map.get(&param_id) {
-            if let Ok(text) = CStr::from_ptr(display).to_str() {
+            if let Ok(text) = unsafe { CStr::from_ptr(display) }.to_str() {
                 let param = &instance.params[index];
                 if let Some(out) = main_thread_state.plugin.parse_param(param_id, text) {
+                    let value = unsafe { &mut *value };
                     *value = map_param_out(param, out);
                     return true;
                 }
@@ -815,35 +828,37 @@ impl<P: Plugin> Instance<P> {
         in_: *const clap_input_events,
         out: *const clap_output_events,
     ) {
-        let instance = &*(plugin as *const Self);
-        let process_state = &mut *instance.process_state.get();
+        let instance = unsafe { &*(plugin as *const Self) };
+        let process_state = unsafe { &mut *instance.process_state.get() };
 
         // If we are in the active state, flush will be called on the audio thread.
         if let Some(engine) = &mut process_state.engine {
             process_state.events.clear();
             instance.sync_engine(&mut process_state.events);
-            instance.process_param_events(in_, &mut process_state.events);
-            instance.process_gestures(
-                &mut process_state.gesture_states,
-                &mut process_state.events,
-                out,
-                0,
-            );
+            unsafe { instance.process_param_events(in_, &mut process_state.events) };
+            unsafe {
+                instance.process_gestures(
+                    &mut process_state.gesture_states,
+                    &mut process_state.events,
+                    out,
+                    0,
+                )
+            };
 
             engine.flush(Events::new(&process_state.events));
         }
         // Otherwise, flush will be called on the main thread.
         else {
-            let main_thread_state = &mut *instance.main_thread_state.get();
+            let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
 
-            let size = (*in_).size.unwrap()(in_);
+            let size = unsafe { (*in_).size.unwrap()(in_) };
             for i in 0..size {
-                let event = (*in_).get.unwrap()(in_, i);
+                let event = unsafe { (*in_).get.unwrap()(in_, i) };
 
-                if (*event).space_id == CLAP_CORE_EVENT_SPACE_ID
-                    && (*event).type_ == CLAP_EVENT_PARAM_VALUE
+                if unsafe { (*event).space_id } == CLAP_CORE_EVENT_SPACE_ID
+                    && unsafe { (*event).type_ } == CLAP_EVENT_PARAM_VALUE
                 {
-                    let event = &*(event as *const clap_event_param_value);
+                    let event = unsafe { &*(event as *const clap_event_param_value) };
 
                     if let Some(&index) = instance.param_map.get(&event.param_id) {
                         let value = map_param_in(&instance.params[index], event.value);
@@ -867,7 +882,7 @@ impl<P: Plugin> Instance<P> {
                     }
                 }
 
-                instance.send_gesture_events(&update, out, 0);
+                unsafe { instance.send_gesture_events(&update, out, 0) };
             }
         }
     }
@@ -907,8 +922,8 @@ impl<P: Plugin> Instance<P> {
             }
         }
 
-        let instance = &*(plugin as *const Self);
-        let main_thread_state = &mut *instance.main_thread_state.get();
+        let instance = unsafe { &*(plugin as *const Self) };
+        let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
 
         instance.sync_plugin(main_thread_state);
         let result = main_thread_state.plugin.save(&mut StreamWriter(stream));
@@ -939,8 +954,8 @@ impl<P: Plugin> Instance<P> {
             }
         }
 
-        let instance = &*(plugin as *const Self);
-        let main_thread_state = &mut *instance.main_thread_state.get();
+        let instance = unsafe { &*(plugin as *const Self) };
+        let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
 
         instance.sync_plugin(main_thread_state);
         if main_thread_state.plugin.load(&mut StreamReader(stream)).is_ok() {

--- a/src/format/clap/mod.rs
+++ b/src/format/clap/mod.rs
@@ -49,7 +49,7 @@ impl EntryPoint {
 macro_rules! clap {
     ($plugin:ty) => {
         #[allow(non_upper_case_globals)]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         static clap_entry: ::coupler::format::clap::EntryPoint = {
             static FACTORY: ::coupler::format::clap::Factory<$plugin> =
                 ::coupler::format::clap::Factory::new();

--- a/src/format/clap/mod.rs
+++ b/src/format/clap/mod.rs
@@ -1,5 +1,3 @@
-#![warn(unsafe_op_in_unsafe_fn)]
-
 use std::ffi::{c_char, c_void};
 
 use clap_sys::{entry::*, version::*};

--- a/src/format/clap/mod.rs
+++ b/src/format/clap/mod.rs
@@ -1,3 +1,5 @@
+#![warn(unsafe_op_in_unsafe_fn)]
+
 use std::ffi::{c_char, c_void};
 
 use clap_sys::{entry::*, version::*};

--- a/src/format/vst3/buffers.rs
+++ b/src/format/vst3/buffers.rs
@@ -12,7 +12,7 @@ use crate::util::slice_from_raw_parts_checked;
 // Alternative to `slice::from_raw_parts` that can be used safely even when passed an unaligned
 // pointer. Creates an iterator that fetches each item in an array using `ptr::read_unaligned`.
 unsafe fn iter_slice_unaligned<T>(ptr: *const T, len: usize) -> impl Iterator<Item = T> {
-    (0..len).map(move |i| ptr::read_unaligned(ptr.add(i)))
+    (0..len).map(move |i| unsafe { ptr::read_unaligned(ptr.add(i)) })
 }
 
 pub struct ScratchBuffers {
@@ -130,8 +130,8 @@ impl ScratchBuffers {
             return Err(());
         }
 
-        let inputs = slice_from_raw_parts_checked(data.inputs, input_count);
-        let outputs = slice_from_raw_parts_checked(data.outputs, output_count);
+        let inputs = unsafe { slice_from_raw_parts_checked(data.inputs, input_count) };
+        let outputs = unsafe { slice_from_raw_parts_checked(data.outputs, output_count) };
 
         // Validate that the host has provided us with the correct number of channels for each bus.
         for (&bus_index, input) in zip(input_bus_map, inputs) {
@@ -151,10 +151,12 @@ impl ScratchBuffers {
             let data = &self.data[bus_index];
             if self.outputs_active[output_index] {
                 let output = &outputs[output_index];
-                let channels = iter_slice_unaligned(
-                    output.__field0.channelBuffers32,
-                    output.numChannels as usize,
-                );
+                let channels = unsafe {
+                    iter_slice_unaligned(
+                        output.__field0.channelBuffers32,
+                        output.numChannels as usize,
+                    )
+                };
 
                 let ptrs = &mut self.ptrs[data.start..data.end];
                 for (channel, ptr) in zip(channels, ptrs) {
@@ -183,10 +185,12 @@ impl ScratchBuffers {
             if bus_info.dir == BusDir::In {
                 if self.inputs_active[input_index] {
                     let input = &inputs[input_index];
-                    let channels = iter_slice_unaligned(
-                        input.__field0.channelBuffers32,
-                        input.numChannels as usize,
-                    );
+                    let channels = unsafe {
+                        iter_slice_unaligned(
+                            input.__field0.channelBuffers32,
+                            input.numChannels as usize,
+                        )
+                    };
 
                     let ptrs = &mut self.ptrs[data.start..data.end];
                     for (channel, ptr) in zip(channels, ptrs) {
@@ -196,7 +200,7 @@ impl ScratchBuffers {
                             let (first, rest) = scratch.split_at_mut(len);
                             scratch = rest;
 
-                            let input_slice = slice::from_raw_parts(channel, len);
+                            let input_slice = unsafe { slice::from_raw_parts(channel, len) };
                             first.copy_from_slice(input_slice);
                             *ptr = first.as_mut_ptr();
                         } else {
@@ -220,10 +224,12 @@ impl ScratchBuffers {
             if bus_info.dir == BusDir::InOut {
                 if self.inputs_active[input_index] {
                     let input = &inputs[input_index];
-                    let channels = iter_slice_unaligned(
-                        input.__field0.channelBuffers32,
-                        input.numChannels as usize,
-                    );
+                    let channels = unsafe {
+                        iter_slice_unaligned(
+                            input.__field0.channelBuffers32,
+                            input.numChannels as usize,
+                        )
+                    };
 
                     let ptrs = &self.ptrs[data.start..data.end];
                     for (src, &dst) in zip(channels, ptrs) {
@@ -236,7 +242,7 @@ impl ScratchBuffers {
                                 let (first, rest) = scratch.split_at_mut(len);
                                 scratch = rest;
 
-                                let input_slice = slice::from_raw_parts(src, len);
+                                let input_slice = unsafe { slice::from_raw_parts(src, len) };
                                 first.copy_from_slice(input_slice);
                                 self.moves.push((first.as_ptr(), dst));
                             } else {
@@ -256,15 +262,15 @@ impl ScratchBuffers {
         // Now that any aliased input buffers have been copied to scratch space, actually perform
         // the copies.
         for (src, dst) in self.moves.drain(..) {
-            let src = slice::from_raw_parts(src, len);
-            let dst = slice::from_raw_parts_mut(dst, len);
+            let src = unsafe { slice::from_raw_parts(src, len) };
+            let dst = unsafe { slice::from_raw_parts_mut(dst, len) };
             dst.copy_from_slice(src);
         }
 
         self.output_ptrs.clear();
 
-        Ok(Some(Buffers::from_raw_parts(
-            &self.data, &self.ptrs, 0, len,
-        )))
+        Ok(Some(unsafe {
+            Buffers::from_raw_parts(&self.data, &self.ptrs, 0, len)
+        }))
     }
 }

--- a/src/format/vst3/component.rs
+++ b/src/format/vst3/component.rs
@@ -193,7 +193,7 @@ impl<P: Plugin> IComponentTrait for Component<P> {
         index: int32,
         bus: *mut vst3::Steinberg::Vst::BusInfo,
     ) -> tresult {
-        let main_thread_state = &*self.main_thread_state.get();
+        let main_thread_state = unsafe { &*self.main_thread_state.get() };
 
         match type_ as MediaTypes {
             MediaTypes_::kAudio => {
@@ -208,7 +208,7 @@ impl<P: Plugin> IComponentTrait for Component<P> {
                     let format = main_thread_state.config.layout.formats.get(bus_index);
 
                     if let (Some(info), Some(format)) = (info, format) {
-                        let bus = &mut *bus;
+                        let bus = unsafe { &mut *bus };
 
                         bus.mediaType = type_;
                         bus.direction = dir;
@@ -247,7 +247,7 @@ impl<P: Plugin> IComponentTrait for Component<P> {
         index: int32,
         state: TBool,
     ) -> tresult {
-        let process_state = &mut *self.process_state.get();
+        let process_state = unsafe { &mut *self.process_state.get() };
 
         match type_ as MediaTypes {
             MediaTypes_::kAudio => match dir as BusDirections {
@@ -273,8 +273,8 @@ impl<P: Plugin> IComponentTrait for Component<P> {
     }
 
     unsafe fn setActive(&self, state: TBool) -> tresult {
-        let main_thread_state = &mut *self.main_thread_state.get();
-        let process_state = &mut *self.process_state.get();
+        let main_thread_state = unsafe { &mut *self.main_thread_state.get() };
+        let process_state = unsafe { &mut *self.process_state.get() };
 
         if state == 0 {
             // Apply any remaining engine -> plugin parameter changes. There won't be any more
@@ -316,8 +316,8 @@ impl<P: Plugin> IComponentTrait for Component<P> {
             }
         }
 
-        if let Some(state) = ComRef::from_raw(state) {
-            let main_thread_state = &mut *self.main_thread_state.get();
+        if let Some(state) = unsafe { ComRef::from_raw(state) } {
+            let main_thread_state = unsafe { &mut *self.main_thread_state.get() };
 
             self.sync_plugin(&mut main_thread_state.plugin);
 
@@ -362,8 +362,8 @@ impl<P: Plugin> IComponentTrait for Component<P> {
             }
         }
 
-        if let Some(state) = ComRef::from_raw(state) {
-            let main_thread_state = &mut *self.main_thread_state.get();
+        if let Some(state) = unsafe { ComRef::from_raw(state) } {
+            let main_thread_state = unsafe { &mut *self.main_thread_state.get() };
 
             self.sync_plugin(&mut main_thread_state.plugin);
 
@@ -394,8 +394,8 @@ impl<P: Plugin> IAudioProcessorTrait for Component<P> {
             formats: Vec::new(),
         };
 
-        let mut inputs = slice_from_raw_parts_checked(inputs, input_count).iter();
-        let mut outputs = slice_from_raw_parts_checked(outputs, output_count).iter();
+        let mut inputs = unsafe { slice_from_raw_parts_checked(inputs, input_count).iter() };
+        let mut outputs = unsafe { slice_from_raw_parts_checked(outputs, output_count).iter() };
         for bus in &self.buses {
             let arrangement = match bus.dir {
                 BusDir::In => *inputs.next().unwrap(),
@@ -418,7 +418,7 @@ impl<P: Plugin> IAudioProcessorTrait for Component<P> {
         }
 
         if self.layout_set.contains(&candidate) {
-            let main_thread_state = &mut *self.main_thread_state.get();
+            let main_thread_state = unsafe { &mut *self.main_thread_state.get() };
             main_thread_state.config.layout = candidate;
             return kResultTrue;
         }
@@ -432,7 +432,7 @@ impl<P: Plugin> IAudioProcessorTrait for Component<P> {
         index: int32,
         arr: *mut SpeakerArrangement,
     ) -> tresult {
-        let main_thread_state = &*self.main_thread_state.get();
+        let main_thread_state = unsafe { &*self.main_thread_state.get() };
 
         let bus_index = match dir as BusDirections {
             BusDirections_::kInput => self.input_bus_map.get(index as usize),
@@ -443,6 +443,7 @@ impl<P: Plugin> IAudioProcessorTrait for Component<P> {
         if let Some(&bus_index) = bus_index {
             #[allow(clippy::unnecessary_cast)] // The type of BusDirection varies by platform
             if let Some(format) = main_thread_state.config.layout.formats.get(bus_index as usize) {
+                let arr = unsafe { &mut *arr };
                 *arr = format_to_speaker_arrangement(format);
                 return kResultOk;
             }
@@ -460,16 +461,16 @@ impl<P: Plugin> IAudioProcessorTrait for Component<P> {
     }
 
     unsafe fn getLatencySamples(&self) -> uint32 {
-        let main_thread_state = &mut *self.main_thread_state.get();
+        let main_thread_state = unsafe { &mut *self.main_thread_state.get() };
 
         self.sync_plugin(&mut main_thread_state.plugin);
         main_thread_state.plugin.latency(&main_thread_state.config) as uint32
     }
 
     unsafe fn setupProcessing(&self, setup: *mut ProcessSetup) -> tresult {
-        let main_thread_state = &mut *self.main_thread_state.get();
+        let main_thread_state = unsafe { &mut *self.main_thread_state.get() };
 
-        let setup = &*setup;
+        let setup = unsafe { &*setup };
         main_thread_state.config.sample_rate = setup.sampleRate;
         main_thread_state.config.max_buffer_size = setup.maxSamplesPerBlock as usize;
 
@@ -477,7 +478,7 @@ impl<P: Plugin> IAudioProcessorTrait for Component<P> {
     }
 
     unsafe fn setProcessing(&self, state: TBool) -> tresult {
-        let process_state = &mut *self.process_state.get();
+        let process_state = unsafe { &mut *self.process_state.get() };
 
         let Some(engine) = &mut process_state.engine else {
             return kNotInitialized;
@@ -507,21 +508,23 @@ impl<P: Plugin> IAudioProcessorTrait for Component<P> {
     }
 
     unsafe fn process(&self, data: *mut ProcessData) -> tresult {
-        let process_state = &mut *self.process_state.get();
+        let process_state = unsafe { &mut *self.process_state.get() };
 
         let Some(engine) = &mut process_state.engine else {
             return kNotInitialized;
         };
 
-        let data = &*data;
+        let data = unsafe { &*data };
 
-        let Ok(buffers) = process_state.scratch_buffers.get_buffers(
-            &self.buses,
-            &self.input_bus_map,
-            &self.output_bus_map,
-            &process_state.config,
-            data,
-        ) else {
+        let Ok(buffers) = (unsafe {
+            process_state.scratch_buffers.get_buffers(
+                &self.buses,
+                &self.input_bus_map,
+                &self.output_bus_map,
+                &process_state.config,
+                data,
+            )
+        }) else {
             return kInvalidArgument;
         };
 
@@ -537,15 +540,15 @@ impl<P: Plugin> IAudioProcessorTrait for Component<P> {
             });
         }
 
-        if let Some(param_changes) = ComRef::from_raw(data.inputParameterChanges) {
-            for index in 0..param_changes.getParameterCount() {
-                let param_data = param_changes.getParameterData(index);
-                let Some(param_data) = ComRef::from_raw(param_data) else {
+        if let Some(param_changes) = unsafe { ComRef::from_raw(data.inputParameterChanges) } {
+            for index in 0..unsafe { param_changes.getParameterCount() } {
+                let param_data = unsafe { param_changes.getParameterData(index) };
+                let Some(param_data) = (unsafe { ComRef::from_raw(param_data) }) else {
                     continue;
                 };
 
-                let id = param_data.getParameterId();
-                let point_count = param_data.getPointCount();
+                let id = unsafe { param_data.getParameterId() };
+                let point_count = unsafe { param_data.getPointCount() };
 
                 let Some(&param_index) = self.param_map.get(&id) else {
                     continue;
@@ -554,7 +557,7 @@ impl<P: Plugin> IAudioProcessorTrait for Component<P> {
                 for index in 0..point_count {
                     let mut offset = 0;
                     let mut value = 0.0;
-                    let result = param_data.getPoint(index, &mut offset, &mut value);
+                    let result = unsafe { param_data.getPoint(index, &mut offset, &mut value) };
 
                     if result != kResultOk {
                         continue;
@@ -610,7 +613,7 @@ impl<P: Plugin> IEditControllerTrait for Component<P> {
 
     unsafe fn getParameterInfo(&self, paramIndex: int32, info: *mut ParameterInfo) -> tresult {
         if let Some(param) = self.params.get(paramIndex as usize) {
-            let info = &mut *info;
+            let info = unsafe { &mut *info };
 
             info.id = param.id as ParamID;
             copy_wstring(&param.name, &mut info.title);
@@ -637,14 +640,14 @@ impl<P: Plugin> IEditControllerTrait for Component<P> {
         valueNormalized: ParamValue,
         string: *mut String128,
     ) -> tresult {
-        let main_thread_state = &*self.main_thread_state.get();
+        let main_thread_state = unsafe { &*self.main_thread_state.get() };
 
         if self.param_map.contains_key(&id) {
             let display = format!(
                 "{}",
                 DisplayParam::new(&main_thread_state.plugin, id, valueNormalized)
             );
-            copy_wstring(&display, &mut *string);
+            copy_wstring(&display, unsafe { &mut *string });
 
             return kResultOk;
         }
@@ -658,12 +661,12 @@ impl<P: Plugin> IEditControllerTrait for Component<P> {
         string: *mut TChar,
         valueNormalized: *mut ParamValue,
     ) -> tresult {
-        let main_thread_state = &*self.main_thread_state.get();
+        let main_thread_state = unsafe { &*self.main_thread_state.get() };
 
         if self.param_map.contains_key(&id) {
-            if let Ok(display) = String::from_utf16(utf16_from_ptr(string)) {
+            if let Ok(display) = String::from_utf16(unsafe { utf16_from_ptr(string) }) {
                 if let Some(value) = main_thread_state.plugin.parse_param(id, &display) {
-                    *valueNormalized = value;
+                    unsafe { *valueNormalized = value };
                     return kResultOk;
                 }
             }
@@ -685,7 +688,7 @@ impl<P: Plugin> IEditControllerTrait for Component<P> {
     }
 
     unsafe fn getParamNormalized(&self, id: ParamID) -> ParamValue {
-        let main_thread_state = &*self.main_thread_state.get();
+        let main_thread_state = unsafe { &*self.main_thread_state.get() };
 
         if self.param_map.contains_key(&id) {
             return main_thread_state.plugin.get_param(id);
@@ -695,7 +698,7 @@ impl<P: Plugin> IEditControllerTrait for Component<P> {
     }
 
     unsafe fn setParamNormalized(&self, id: ParamID, value: ParamValue) -> tresult {
-        let main_thread_state = &mut *self.main_thread_state.get();
+        let main_thread_state = unsafe { &mut *self.main_thread_state.get() };
 
         if self.param_map.contains_key(&id) {
             main_thread_state.plugin.set_param(id, value);
@@ -711,10 +714,10 @@ impl<P: Plugin> IEditControllerTrait for Component<P> {
     }
 
     unsafe fn setComponentHandler(&self, handler: *mut IComponentHandler) -> tresult {
-        let main_thread_state = &mut *self.main_thread_state.get();
+        let main_thread_state = unsafe { &mut *self.main_thread_state.get() };
 
         let mut current_handler = main_thread_state.view_host.handler.borrow_mut();
-        if let Some(handler) = ComRef::from_raw(handler) {
+        if let Some(handler) = unsafe { ComRef::from_raw(handler) } {
             *current_handler = Some(handler.to_com_ptr());
         } else {
             *current_handler = None;
@@ -728,7 +731,7 @@ impl<P: Plugin> IEditControllerTrait for Component<P> {
             return ptr::null_mut();
         }
 
-        if CStr::from_ptr(name) != CStr::from_ptr(ViewType::kEditor) {
+        if unsafe { CStr::from_ptr(name) } != unsafe { CStr::from_ptr(ViewType::kEditor) } {
             return ptr::null_mut();
         }
 

--- a/src/format/vst3/factory.rs
+++ b/src/format/vst3/factory.rs
@@ -35,7 +35,7 @@ impl<P: Plugin> Class for Factory<P> {
 
 impl<P: Plugin> IPluginFactoryTrait for Factory<P> {
     unsafe fn getFactoryInfo(&self, info: *mut PFactoryInfo) -> tresult {
-        let info = &mut *info;
+        let info = unsafe { &mut *info };
 
         copy_cstring(&self.info.vendor, &mut info.vendor);
         copy_cstring(&self.info.url, &mut info.url);
@@ -51,7 +51,7 @@ impl<P: Plugin> IPluginFactoryTrait for Factory<P> {
 
     unsafe fn getClassInfo(&self, index: int32, info: *mut PClassInfo) -> tresult {
         if index == 0 {
-            let info = &mut *info;
+            let info = unsafe { &mut *info };
 
             info.cid = uuid_to_tuid(&self.vst3_info.class_id);
             info.cardinality = PClassInfo_::ClassCardinality_::kManyInstances as int32;
@@ -70,13 +70,13 @@ impl<P: Plugin> IPluginFactoryTrait for Factory<P> {
         iid: FIDString,
         obj: *mut *mut c_void,
     ) -> tresult {
-        let cid = &*(cid as *const TUID);
+        let cid = unsafe { &*(cid as *const TUID) };
         let class_id = uuid_to_tuid(&self.vst3_info.class_id);
         if cid == &class_id {
             let component = ComWrapper::new(Component::<P>::new());
             let unknown = component.as_com_ref::<FUnknown>().unwrap();
             let ptr = unknown.as_ptr();
-            return ((*(*ptr).vtbl).queryInterface)(ptr, iid as *const TUID, obj);
+            return unsafe { ((*(*ptr).vtbl).queryInterface)(ptr, iid as *const TUID, obj) };
         }
 
         kInvalidArgument
@@ -86,7 +86,7 @@ impl<P: Plugin> IPluginFactoryTrait for Factory<P> {
 impl<P: Plugin> IPluginFactory2Trait for Factory<P> {
     unsafe fn getClassInfo2(&self, index: int32, info: *mut PClassInfo2) -> tresult {
         if index == 0 {
-            let info = &mut *info;
+            let info = unsafe { &mut *info };
 
             info.cid = uuid_to_tuid(&self.vst3_info.class_id);
             info.cardinality = PClassInfo_::ClassCardinality_::kManyInstances as int32;
@@ -96,7 +96,7 @@ impl<P: Plugin> IPluginFactory2Trait for Factory<P> {
             copy_cstring("Fx", &mut info.subCategories);
             copy_cstring(&self.info.vendor, &mut info.vendor);
             copy_cstring(&self.info.version, &mut info.version);
-            let version_str = CStr::from_ptr(SDKVersionString).to_str().unwrap();
+            let version_str = unsafe { CStr::from_ptr(SDKVersionString) }.to_str().unwrap();
             copy_cstring(version_str, &mut info.sdkVersion);
 
             return kResultOk;
@@ -109,7 +109,7 @@ impl<P: Plugin> IPluginFactory2Trait for Factory<P> {
 impl<P: Plugin> IPluginFactory3Trait for Factory<P> {
     unsafe fn getClassInfoUnicode(&self, index: int32, info: *mut PClassInfoW) -> tresult {
         if index == 0 {
-            let info = &mut *info;
+            let info = unsafe { &mut *info };
 
             info.cid = uuid_to_tuid(&self.vst3_info.class_id);
             info.cardinality = PClassInfo_::ClassCardinality_::kManyInstances as int32;
@@ -119,7 +119,7 @@ impl<P: Plugin> IPluginFactory3Trait for Factory<P> {
             copy_cstring("Fx", &mut info.subCategories);
             copy_wstring(&self.info.vendor, &mut info.vendor);
             copy_wstring(&self.info.version, &mut info.version);
-            let version_str = CStr::from_ptr(SDKVersionString).to_str().unwrap();
+            let version_str = unsafe { CStr::from_ptr(SDKVersionString) }.to_str().unwrap();
             copy_wstring(version_str, &mut info.sdkVersion);
 
             return kResultOk;

--- a/src/format/vst3/mod.rs
+++ b/src/format/vst3/mod.rs
@@ -1,3 +1,4 @@
+#![warn(unsafe_op_in_unsafe_fn)]
 #![allow(non_snake_case)]
 
 use std::ffi::c_void;

--- a/src/format/vst3/mod.rs
+++ b/src/format/vst3/mod.rs
@@ -57,42 +57,42 @@ pub fn get_plugin_factory<P: Plugin + Vst3Plugin>() -> *mut c_void {
 macro_rules! vst3 {
     ($plugin:ty) => {
         #[cfg(target_os = "windows")]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         extern "system" fn InitDll() -> bool {
             true
         }
 
         #[cfg(target_os = "windows")]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         extern "system" fn ExitDll() -> bool {
             true
         }
 
         #[cfg(target_os = "macos")]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         extern "system" fn bundleEntry(_bundle_ref: *mut ::std::ffi::c_void) -> bool {
             true
         }
 
         #[cfg(target_os = "macos")]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         extern "system" fn bundleExit() -> bool {
             true
         }
 
         #[cfg(target_os = "linux")]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         extern "system" fn ModuleEntry(_library_handle: *mut ::std::ffi::c_void) -> bool {
             true
         }
 
         #[cfg(target_os = "linux")]
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         extern "system" fn ModuleExit() -> bool {
             true
         }
 
-        #[no_mangle]
+        #[unsafe(no_mangle)]
         extern "system" fn GetPluginFactory() -> *mut ::std::ffi::c_void {
             ::coupler::format::vst3::get_plugin_factory::<$plugin>()
         }

--- a/src/format/vst3/mod.rs
+++ b/src/format/vst3/mod.rs
@@ -1,4 +1,3 @@
-#![warn(unsafe_op_in_unsafe_fn)]
 #![allow(non_snake_case)]
 
 use std::ffi::c_void;

--- a/src/format/vst3/util.rs
+++ b/src/format/vst3/util.rs
@@ -18,9 +18,9 @@ pub fn copy_wstring(src: &str, dst: &mut [char16]) {
 
 pub unsafe fn utf16_from_ptr<'a>(ptr: *const char16) -> &'a [u16] {
     let mut len = 0;
-    while *ptr.add(len) != 0 {
+    while unsafe { *ptr.add(len) } != 0 {
         len += 1;
     }
 
-    slice::from_raw_parts(ptr, len)
+    unsafe { slice::from_raw_parts(ptr, len) }
 }

--- a/src/format/vst3/view.rs
+++ b/src/format/vst3/view.rs
@@ -70,17 +70,19 @@ impl<P: Plugin> Class for PlugView<P> {
 impl<P: Plugin> IPlugViewTrait for PlugView<P> {
     unsafe fn isPlatformTypeSupported(&self, type_: FIDString) -> tresult {
         #[cfg(target_os = "windows")]
-        if CStr::from_ptr(type_) == CStr::from_ptr(kPlatformTypeHWND) {
+        if unsafe { CStr::from_ptr(type_) } == unsafe { CStr::from_ptr(kPlatformTypeHWND) } {
             return kResultTrue;
         }
 
         #[cfg(target_os = "macos")]
-        if CStr::from_ptr(type_) == CStr::from_ptr(kPlatformTypeNSView) {
+        if unsafe { CStr::from_ptr(type_) } == unsafe { CStr::from_ptr(kPlatformTypeNSView) } {
             return kResultTrue;
         }
 
         #[cfg(target_os = "linux")]
-        if CStr::from_ptr(type_) == CStr::from_ptr(kPlatformTypeX11EmbedWindowID) {
+        if unsafe { CStr::from_ptr(type_) }
+            == unsafe { CStr::from_ptr(kPlatformTypeX11EmbedWindowID) }
+        {
             return kResultTrue;
         }
 
@@ -88,7 +90,7 @@ impl<P: Plugin> IPlugViewTrait for PlugView<P> {
     }
 
     unsafe fn attached(&self, parent: *mut c_void, type_: FIDString) -> tresult {
-        if self.isPlatformTypeSupported(type_) != kResultTrue {
+        if unsafe { self.isPlatformTypeSupported(type_) } != kResultTrue {
             return kResultFalse;
         }
 
@@ -101,10 +103,10 @@ impl<P: Plugin> IPlugViewTrait for PlugView<P> {
         #[cfg(target_os = "linux")]
         let raw_parent = RawParent::X11(parent as std::ffi::c_ulong);
 
-        let main_thread_state = &mut *self.main_thread_state.get();
+        let main_thread_state = unsafe { &mut *self.main_thread_state.get() };
 
         let host = ViewHost::from_inner(main_thread_state.view_host.clone());
-        let parent = ParentWindow::from_raw(raw_parent);
+        let parent = unsafe { ParentWindow::from_raw(raw_parent) };
         let view = main_thread_state.plugin.view(host, &parent);
         main_thread_state.view = Some(view);
 
@@ -112,7 +114,7 @@ impl<P: Plugin> IPlugViewTrait for PlugView<P> {
     }
 
     unsafe fn removed(&self) -> tresult {
-        let main_thread_state = &mut *self.main_thread_state.get();
+        let main_thread_state = unsafe { &mut *self.main_thread_state.get() };
 
         main_thread_state.view = None;
 
@@ -136,12 +138,12 @@ impl<P: Plugin> IPlugViewTrait for PlugView<P> {
             return kResultFalse;
         }
 
-        let main_thread_state = &*self.main_thread_state.get();
+        let main_thread_state = unsafe { &*self.main_thread_state.get() };
 
         if let Some(view) = &main_thread_state.view {
             let view_size = view.size();
 
-            let rect = &mut *size;
+            let rect = unsafe { &mut *size };
             rect.left = 0;
             rect.top = 0;
             rect.right = view_size.width.round() as int32;
@@ -162,8 +164,9 @@ impl<P: Plugin> IPlugViewTrait for PlugView<P> {
     }
 
     unsafe fn setFrame(&self, frame: *mut IPlugFrame) -> tresult {
-        let main_thread_state = &mut *self.main_thread_state.get();
-        main_thread_state.frame = ComRef::from_raw(frame).map(|frame| frame.to_com_ptr());
+        let main_thread_state = unsafe { &mut *self.main_thread_state.get() };
+        main_thread_state.frame =
+            unsafe { ComRef::from_raw(frame) }.map(|frame| frame.to_com_ptr());
 
         kResultOk
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![warn(unsafe_op_in_unsafe_fn)]
 #![allow(clippy::missing_safety_doc)]
 
 pub mod buffers;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![warn(unsafe_op_in_unsafe_fn)]
 #![allow(clippy::missing_safety_doc)]
 
 pub mod buffers;

--- a/src/util.rs
+++ b/src/util.rs
@@ -27,7 +27,7 @@ pub fn copy_cstring(src: &str, dst: &mut [c_char]) {
 // is nonzero before calling `from_raw_parts`.
 pub unsafe fn slice_from_raw_parts_checked<'a, T>(ptr: *const T, len: usize) -> &'a [T] {
     if len > 0 {
-        slice::from_raw_parts(ptr, len)
+        unsafe { slice::from_raw_parts(ptr, len) }
     } else {
         &[]
     }


### PR DESCRIPTION
The 2024 Rust edition enables the `unsafe_op_in_unsafe_fn` warning by default and makes `unsafe_attr_outside_unsafe` a hard error.