### PR TITLE
protect MainThreadState and ProcessState with SyncCell

### DIFF
--- a/src/format/clap/gui.rs
+++ b/src/format/clap/gui.rs
@@ -115,7 +115,7 @@ impl<P: Plugin> Instance<P> {
 
     unsafe extern "C" fn gui_destroy(plugin: *const clap_plugin) {
         let instance = unsafe { &*(plugin as *const Self) };
-        let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
+        let mut main_thread_state = instance.main_thread_state.borrow();
 
         main_thread_state.editor = None;
     }
@@ -130,7 +130,7 @@ impl<P: Plugin> Instance<P> {
         height: *mut u32,
     ) -> bool {
         let instance = unsafe { &*(plugin as *const Self) };
-        let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
+        let main_thread_state = instance.main_thread_state.borrow();
 
         if let Some(editor) = &main_thread_state.editor {
             let size = editor.size();
@@ -194,7 +194,7 @@ impl<P: Plugin> Instance<P> {
         let raw_parent = { RawParent::X11(unsafe { window.specific.x11 }) };
 
         let instance = unsafe { &*(plugin as *const Self) };
-        let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
+        let mut main_thread_state = instance.main_thread_state.borrow();
 
         let host = EditorHost::from_inner(Rc::new(ClapEditorHost {
             host: instance.host,

--- a/src/format/clap/instance.rs
+++ b/src/format/clap/instance.rs
@@ -1,4 +1,3 @@
-use std::cell::UnsafeCell;
 use std::collections::HashMap;
 use std::ffi::{CStr, c_char, c_void};
 use std::iter::zip;
@@ -20,6 +19,7 @@ use crate::plugin::Plugin;
 use crate::process::{Config, Processor};
 use crate::sync::param_gestures::{GestureStates, GestureUpdate, ParamGestures};
 use crate::sync::params::ParamValues;
+use crate::sync::sync_cell::SyncCell;
 use crate::util::{DisplayParam, copy_cstring, slice_from_raw_parts_checked};
 
 fn port_type_from_format(format: &Format) -> &'static CStr {
@@ -77,8 +77,8 @@ pub struct Instance<P: Plugin> {
     pub processor_params: ParamValues,
     pub param_gestures: Arc<ParamGestures>,
     pub has_editor: bool,
-    pub main_thread_state: UnsafeCell<MainThreadState<P>>,
-    pub process_state: UnsafeCell<ProcessState<P>>,
+    pub main_thread_state: SyncCell<MainThreadState<P>>,
+    pub process_state: SyncCell<ProcessState<P>>,
 }
 
 unsafe impl<P: Plugin> Sync for Instance<P> {}
@@ -139,13 +139,13 @@ impl<P: Plugin> Instance<P> {
             processor_params: ParamValues::with_count(param_count),
             param_gestures: Arc::new(ParamGestures::with_count(param_count)),
             has_editor,
-            main_thread_state: UnsafeCell::new(MainThreadState {
+            main_thread_state: SyncCell::new(MainThreadState {
                 host_params: None,
                 layout_index: 0,
                 plugin,
                 editor: None,
             }),
-            process_state: UnsafeCell::new(ProcessState {
+            process_state: SyncCell::new(ProcessState {
                 gesture_states: GestureStates::with_count(param_count),
                 buffer_data: Vec::new(),
                 buffer_ptrs: Vec::new(),
@@ -322,7 +322,7 @@ impl<P: Plugin> Instance<P> {
 impl<P: Plugin> Instance<P> {
     unsafe extern "C" fn init(plugin: *const clap_plugin) -> bool {
         let instance = unsafe { &*(plugin as *const Self) };
-        let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
+        let mut main_thread_state = instance.main_thread_state.borrow();
 
         let host_params = unsafe {
             (*instance.host).get_extension.unwrap()(instance.host, CLAP_EXT_PARAMS.as_ptr())
@@ -343,8 +343,8 @@ impl<P: Plugin> Instance<P> {
         max_frames_count: u32,
     ) -> bool {
         let instance = unsafe { &*(plugin as *const Self) };
-        let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
-        let process_state = unsafe { &mut *instance.process_state.get() };
+        let mut main_thread_state = instance.main_thread_state.borrow();
+        let mut process_state = instance.process_state.borrow();
 
         let layout = &instance.layouts[main_thread_state.layout_index];
 
@@ -385,12 +385,12 @@ impl<P: Plugin> Instance<P> {
 
     unsafe extern "C" fn deactivate(plugin: *const clap_plugin) {
         let instance = unsafe { &*(plugin as *const Self) };
-        let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
-        let process_state = unsafe { &mut *instance.process_state.get() };
+        let mut main_thread_state = instance.main_thread_state.borrow();
+        let mut process_state = instance.process_state.borrow();
 
         // Apply any remaining processor -> plugin parameter changes. There won't be any more until
         // the next call to `activate`.
-        instance.sync_plugin(main_thread_state);
+        instance.sync_plugin(&mut *main_thread_state);
 
         process_state.processor = None;
     }
@@ -403,7 +403,8 @@ impl<P: Plugin> Instance<P> {
 
     unsafe extern "C" fn reset(plugin: *const clap_plugin) {
         let instance = unsafe { &*(plugin as *const Self) };
-        let process_state = unsafe { &mut *instance.process_state.get() };
+        let mut process_state_guard = instance.process_state.borrow();
+        let process_state = &mut *process_state_guard;
 
         if let Some(processor) = &mut process_state.processor {
             // Flush plugin -> processor parameter changes
@@ -423,7 +424,8 @@ impl<P: Plugin> Instance<P> {
         process: *const clap_process,
     ) -> clap_process_status {
         let instance = unsafe { &*(plugin as *const Self) };
-        let process_state = unsafe { &mut *instance.process_state.get() };
+        let mut process_state_guard = instance.process_state.borrow();
+        let process_state = &mut *process_state_guard;
 
         let Some(processor) = &mut process_state.processor else {
             return CLAP_PROCESS_ERROR;
@@ -550,9 +552,9 @@ impl<P: Plugin> Instance<P> {
 
     unsafe extern "C" fn on_main_thread(plugin: *const clap_plugin) {
         let instance = unsafe { &*(plugin as *const Self) };
-        let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
+        let mut main_thread_state = instance.main_thread_state.borrow();
 
-        instance.sync_plugin(main_thread_state);
+        instance.sync_plugin(&mut *main_thread_state);
     }
 }
 
@@ -579,7 +581,7 @@ impl<P: Plugin> Instance<P> {
         info: *mut clap_audio_port_info,
     ) -> bool {
         let instance = unsafe { &*(plugin as *const Self) };
-        let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
+        let main_thread_state = instance.main_thread_state.borrow();
 
         let bus_index = if is_input {
             instance.input_bus_map.get(index as usize)
@@ -689,7 +691,7 @@ impl<P: Plugin> Instance<P> {
         config_id: clap_id,
     ) -> bool {
         let instance = unsafe { &*(plugin as *const Self) };
-        let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
+        let mut main_thread_state = instance.main_thread_state.borrow();
 
         if instance.layouts.get(config_id as usize).is_some() {
             main_thread_state.layout_index = config_id as usize;
@@ -753,10 +755,10 @@ impl<P: Plugin> Instance<P> {
         value: *mut f64,
     ) -> bool {
         let instance = unsafe { &*(plugin as *const Self) };
-        let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
+        let mut main_thread_state = instance.main_thread_state.borrow();
 
         if let Some(&index) = instance.param_map.get(&param_id) {
-            instance.sync_plugin(main_thread_state);
+            instance.sync_plugin(&mut *main_thread_state);
 
             let param = &instance.params[index];
             let value = unsafe { &mut *value };
@@ -775,7 +777,7 @@ impl<P: Plugin> Instance<P> {
         size: u32,
     ) -> bool {
         let instance = unsafe { &*(plugin as *const Self) };
-        let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
+        let main_thread_state = instance.main_thread_state.borrow();
 
         if let Some(&index) = instance.param_map.get(&param_id) {
             let param = &instance.params[index];
@@ -805,7 +807,7 @@ impl<P: Plugin> Instance<P> {
         value: *mut f64,
     ) -> bool {
         let instance = unsafe { &*(plugin as *const Self) };
-        let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
+        let main_thread_state = instance.main_thread_state.borrow();
 
         if let Some(&index) = instance.param_map.get(&param_id) {
             if let Ok(text) = unsafe { CStr::from_ptr(display) }.to_str() {
@@ -829,7 +831,8 @@ impl<P: Plugin> Instance<P> {
         out: *const clap_output_events,
     ) {
         let instance = unsafe { &*(plugin as *const Self) };
-        let process_state = unsafe { &mut *instance.process_state.get() };
+        let mut process_state_guard = instance.process_state.borrow();
+        let process_state = &mut *process_state_guard;
 
         // If we are in the active state, flush will be called on the audio thread.
         if let Some(processor) = &mut process_state.processor {
@@ -849,7 +852,7 @@ impl<P: Plugin> Instance<P> {
         }
         // Otherwise, flush will be called on the main thread.
         else {
-            let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
+            let mut main_thread_state = instance.main_thread_state.borrow();
 
             let size = unsafe { (*in_).size.unwrap()(in_) };
             for i in 0..size {
@@ -923,9 +926,9 @@ impl<P: Plugin> Instance<P> {
         }
 
         let instance = unsafe { &*(plugin as *const Self) };
-        let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
+        let mut main_thread_state = instance.main_thread_state.borrow();
 
-        instance.sync_plugin(main_thread_state);
+        instance.sync_plugin(&mut *main_thread_state);
         let result = main_thread_state.plugin.save(&mut StreamWriter(stream));
         result.is_ok()
     }
@@ -955,9 +958,9 @@ impl<P: Plugin> Instance<P> {
         }
 
         let instance = unsafe { &*(plugin as *const Self) };
-        let main_thread_state = unsafe { &mut *instance.main_thread_state.get() };
+        let mut main_thread_state = instance.main_thread_state.borrow();
 
-        instance.sync_plugin(main_thread_state);
+        instance.sync_plugin(&mut *main_thread_state);
         if main_thread_state.plugin.load(&mut StreamReader(stream)).is_ok() {
             for (index, param) in instance.params.iter().enumerate() {
                 let value = main_thread_state.plugin.get_param(param.id);

--- a/src/format/vst3/component.rs
+++ b/src/format/vst3/component.rs
@@ -1,4 +1,3 @@
-use std::cell::UnsafeCell;
 use std::collections::{HashMap, HashSet};
 use std::ffi::{CStr, c_void};
 use std::ptr;
@@ -19,6 +18,7 @@ use crate::params::{ParamId, ParamInfo};
 use crate::plugin::Plugin;
 use crate::process::{Config, Processor};
 use crate::sync::params::ParamValues;
+use crate::sync::sync_cell::SyncCell;
 use crate::util::{DisplayParam, slice_from_raw_parts_checked};
 
 fn format_to_speaker_arrangement(format: &Format) -> SpeakerArrangement {
@@ -62,11 +62,11 @@ pub struct Component<P: Plugin> {
     processor_params: ParamValues,
     _host: Arc<Vst3Host>,
     has_editor: bool,
-    main_thread_state: Arc<UnsafeCell<MainThreadState<P>>>,
+    main_thread_state: Arc<SyncCell<MainThreadState<P>>>,
     // When the audio processor is *not* active, references to ProcessState may only be formed from
     // the main thread. When the audio processor *is* active, references to ProcessState may only
     // be formed from the audio thread.
-    process_state: UnsafeCell<ProcessState<P>>,
+    process_state: SyncCell<ProcessState<P>>,
 }
 
 impl<P: Plugin> Component<P> {
@@ -122,14 +122,14 @@ impl<P: Plugin> Component<P> {
             processor_params: ParamValues::with_count(param_count),
             _host: host,
             has_editor,
-            main_thread_state: Arc::new(UnsafeCell::new(MainThreadState {
+            main_thread_state: Arc::new(SyncCell::new(MainThreadState {
                 config: config.clone(),
                 plugin,
                 editor_host: Rc::new(Vst3EditorHost::new()),
                 editor: None,
                 frame: None,
             })),
-            process_state: UnsafeCell::new(ProcessState {
+            process_state: SyncCell::new(ProcessState {
                 config,
                 scratch_buffers,
                 events: Vec::with_capacity(4096),
@@ -193,7 +193,7 @@ impl<P: Plugin> IComponentTrait for Component<P> {
         index: int32,
         bus: *mut vst3::Steinberg::Vst::BusInfo,
     ) -> tresult {
-        let main_thread_state = unsafe { &*self.main_thread_state.get() };
+        let main_thread_state = self.main_thread_state.borrow();
 
         match type_ as MediaTypes {
             MediaTypes_::kAudio => {
@@ -247,7 +247,7 @@ impl<P: Plugin> IComponentTrait for Component<P> {
         index: int32,
         state: TBool,
     ) -> tresult {
-        let process_state = unsafe { &mut *self.process_state.get() };
+        let mut process_state = self.process_state.borrow();
 
         match type_ as MediaTypes {
             MediaTypes_::kAudio => match dir as BusDirections {
@@ -273,8 +273,9 @@ impl<P: Plugin> IComponentTrait for Component<P> {
     }
 
     unsafe fn setActive(&self, state: TBool) -> tresult {
-        let main_thread_state = unsafe { &mut *self.main_thread_state.get() };
-        let process_state = unsafe { &mut *self.process_state.get() };
+        let mut main_thread_state = self.main_thread_state.borrow();
+        let mut process_state_guard = self.process_state.borrow();
+        let process_state = &mut *process_state_guard;
 
         if state == 0 {
             // Apply any remaining processor -> plugin parameter changes. There won't be any more
@@ -318,7 +319,7 @@ impl<P: Plugin> IComponentTrait for Component<P> {
         }
 
         if let Some(state) = unsafe { ComRef::from_raw(state) } {
-            let main_thread_state = unsafe { &mut *self.main_thread_state.get() };
+            let mut main_thread_state = self.main_thread_state.borrow();
 
             self.sync_plugin(&mut main_thread_state.plugin);
 
@@ -364,7 +365,7 @@ impl<P: Plugin> IComponentTrait for Component<P> {
         }
 
         if let Some(state) = unsafe { ComRef::from_raw(state) } {
-            let main_thread_state = unsafe { &mut *self.main_thread_state.get() };
+            let mut main_thread_state = self.main_thread_state.borrow();
 
             self.sync_plugin(&mut main_thread_state.plugin);
 
@@ -419,7 +420,7 @@ impl<P: Plugin> IAudioProcessorTrait for Component<P> {
         }
 
         if self.layout_set.contains(&candidate) {
-            let main_thread_state = unsafe { &mut *self.main_thread_state.get() };
+            let mut main_thread_state = self.main_thread_state.borrow();
             main_thread_state.config.layout = candidate;
             return kResultTrue;
         }
@@ -433,7 +434,7 @@ impl<P: Plugin> IAudioProcessorTrait for Component<P> {
         index: int32,
         arr: *mut SpeakerArrangement,
     ) -> tresult {
-        let main_thread_state = unsafe { &*self.main_thread_state.get() };
+        let main_thread_state = self.main_thread_state.borrow();
 
         let bus_index = match dir as BusDirections {
             BusDirections_::kInput => self.input_bus_map.get(index as usize),
@@ -462,14 +463,14 @@ impl<P: Plugin> IAudioProcessorTrait for Component<P> {
     }
 
     unsafe fn getLatencySamples(&self) -> uint32 {
-        let main_thread_state = unsafe { &mut *self.main_thread_state.get() };
+        let mut main_thread_state = self.main_thread_state.borrow();
 
         self.sync_plugin(&mut main_thread_state.plugin);
         main_thread_state.plugin.latency(&main_thread_state.config) as uint32
     }
 
     unsafe fn setupProcessing(&self, setup: *mut ProcessSetup) -> tresult {
-        let main_thread_state = unsafe { &mut *self.main_thread_state.get() };
+        let mut main_thread_state = self.main_thread_state.borrow();
 
         let setup = unsafe { &*setup };
         main_thread_state.config.sample_rate = setup.sampleRate;
@@ -479,7 +480,8 @@ impl<P: Plugin> IAudioProcessorTrait for Component<P> {
     }
 
     unsafe fn setProcessing(&self, state: TBool) -> tresult {
-        let process_state = unsafe { &mut *self.process_state.get() };
+        let mut process_state_guard = self.process_state.borrow();
+        let process_state = &mut *process_state_guard;
 
         let Some(processor) = &mut process_state.processor else {
             return kNotInitialized;
@@ -509,7 +511,8 @@ impl<P: Plugin> IAudioProcessorTrait for Component<P> {
     }
 
     unsafe fn process(&self, data: *mut ProcessData) -> tresult {
-        let process_state = unsafe { &mut *self.process_state.get() };
+        let mut process_state_guard = self.process_state.borrow();
+        let process_state = &mut *process_state_guard;
 
         let Some(processor) = &mut process_state.processor else {
             return kNotInitialized;
@@ -641,7 +644,7 @@ impl<P: Plugin> IEditControllerTrait for Component<P> {
         valueNormalized: ParamValue,
         string: *mut String128,
     ) -> tresult {
-        let main_thread_state = unsafe { &*self.main_thread_state.get() };
+        let main_thread_state = self.main_thread_state.borrow();
 
         if self.param_map.contains_key(&id) {
             let display = format!(
@@ -662,7 +665,7 @@ impl<P: Plugin> IEditControllerTrait for Component<P> {
         string: *mut TChar,
         valueNormalized: *mut ParamValue,
     ) -> tresult {
-        let main_thread_state = unsafe { &*self.main_thread_state.get() };
+        let main_thread_state = self.main_thread_state.borrow();
 
         if self.param_map.contains_key(&id) {
             if let Ok(display) = String::from_utf16(unsafe { utf16_from_ptr(string) }) {
@@ -689,7 +692,7 @@ impl<P: Plugin> IEditControllerTrait for Component<P> {
     }
 
     unsafe fn getParamNormalized(&self, id: ParamID) -> ParamValue {
-        let main_thread_state = unsafe { &*self.main_thread_state.get() };
+        let main_thread_state = self.main_thread_state.borrow();
 
         if self.param_map.contains_key(&id) {
             return main_thread_state.plugin.get_param(id);
@@ -699,7 +702,7 @@ impl<P: Plugin> IEditControllerTrait for Component<P> {
     }
 
     unsafe fn setParamNormalized(&self, id: ParamID, value: ParamValue) -> tresult {
-        let main_thread_state = unsafe { &mut *self.main_thread_state.get() };
+        let mut main_thread_state = self.main_thread_state.borrow();
 
         if self.param_map.contains_key(&id) {
             main_thread_state.plugin.set_param(id, value);
@@ -715,7 +718,7 @@ impl<P: Plugin> IEditControllerTrait for Component<P> {
     }
 
     unsafe fn setComponentHandler(&self, handler: *mut IComponentHandler) -> tresult {
-        let main_thread_state = unsafe { &mut *self.main_thread_state.get() };
+        let main_thread_state = self.main_thread_state.borrow();
 
         let mut current_handler = main_thread_state.editor_host.handler.borrow_mut();
         if let Some(handler) = unsafe { ComRef::from_raw(handler) } {

--- a/src/format/vst3/view.rs
+++ b/src/format/vst3/view.rs
@@ -1,4 +1,4 @@
-use std::cell::{RefCell, UnsafeCell};
+use std::cell::RefCell;
 use std::ffi::{CStr, c_void};
 use std::sync::Arc;
 
@@ -9,6 +9,7 @@ use super::component::MainThreadState;
 use crate::editor::{Editor, EditorHost, EditorHostInner, ParentWindow, RawParent};
 use crate::params::{ParamId, ParamValue};
 use crate::plugin::Plugin;
+use crate::sync::sync_cell::SyncCell;
 
 pub struct Vst3EditorHost {
     pub handler: RefCell<Option<ComPtr<IComponentHandler>>>,
@@ -52,11 +53,11 @@ impl EditorHostInner for Vst3EditorHost {
 }
 
 pub struct PlugView<P: Plugin> {
-    main_thread_state: Arc<UnsafeCell<MainThreadState<P>>>,
+    main_thread_state: Arc<SyncCell<MainThreadState<P>>>,
 }
 
 impl<P: Plugin> PlugView<P> {
-    pub fn new(main_thread_state: &Arc<UnsafeCell<MainThreadState<P>>>) -> PlugView<P> {
+    pub fn new(main_thread_state: &Arc<SyncCell<MainThreadState<P>>>) -> PlugView<P> {
         PlugView {
             main_thread_state: main_thread_state.clone(),
         }
@@ -103,7 +104,7 @@ impl<P: Plugin> IPlugViewTrait for PlugView<P> {
         #[cfg(target_os = "linux")]
         let raw_parent = RawParent::X11(parent as std::ffi::c_ulong);
 
-        let main_thread_state = unsafe { &mut *self.main_thread_state.get() };
+        let mut main_thread_state = self.main_thread_state.borrow();
 
         let host = EditorHost::from_inner(main_thread_state.editor_host.clone());
         let parent = unsafe { ParentWindow::from_raw(raw_parent) };
@@ -114,7 +115,7 @@ impl<P: Plugin> IPlugViewTrait for PlugView<P> {
     }
 
     unsafe fn removed(&self) -> tresult {
-        let main_thread_state = unsafe { &mut *self.main_thread_state.get() };
+        let mut main_thread_state = self.main_thread_state.borrow();
 
         main_thread_state.editor = None;
 
@@ -138,7 +139,7 @@ impl<P: Plugin> IPlugViewTrait for PlugView<P> {
             return kResultFalse;
         }
 
-        let main_thread_state = unsafe { &*self.main_thread_state.get() };
+        let main_thread_state = self.main_thread_state.borrow();
 
         if let Some(editor) = &main_thread_state.editor {
             let editor_size = editor.size();
@@ -164,7 +165,7 @@ impl<P: Plugin> IPlugViewTrait for PlugView<P> {
     }
 
     unsafe fn setFrame(&self, frame: *mut IPlugFrame) -> tresult {
-        let main_thread_state = unsafe { &mut *self.main_thread_state.get() };
+        let mut main_thread_state = self.main_thread_state.borrow();
         main_thread_state.frame =
             unsafe { ComRef::from_raw(frame) }.map(|frame| frame.to_com_ptr());
 

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -2,3 +2,4 @@ pub mod bitset;
 pub mod float;
 pub mod param_gestures;
 pub mod params;
+pub mod sync_cell;

--- a/src/sync/sync_cell.rs
+++ b/src/sync/sync_cell.rs
@@ -1,0 +1,78 @@
+use std::cell::UnsafeCell;
+use std::error::Error;
+use std::fmt;
+use std::ops::{Deref, DerefMut};
+use std::sync::atomic::{AtomicBool, Ordering};
+
+/// A mutable memory location that can be shared between threads.
+///
+/// `SyncCell` can be thought of as a thread-safe version of `RefCell` or, alternatively, as a
+/// version of `Mutex` that does not support blocking.
+pub struct SyncCell<T> {
+    borrowed: AtomicBool,
+    data: UnsafeCell<T>,
+}
+
+unsafe impl<T: Send> Send for SyncCell<T> {}
+unsafe impl<T: Send> Sync for SyncCell<T> {}
+
+impl<T> SyncCell<T> {
+    pub fn new(data: T) -> SyncCell<T> {
+        SyncCell {
+            borrowed: AtomicBool::new(false),
+            data: UnsafeCell::new(data),
+        }
+    }
+
+    pub fn try_borrow(&self) -> Result<Guard<'_, T>, BorrowMutError> {
+        match self.borrowed.swap(true, Ordering::Acquire) {
+            false => Ok(Guard { cell: self }),
+            true => Err(BorrowMutError {}),
+        }
+    }
+
+    pub fn borrow(&self) -> Guard<'_, T> {
+        match self.try_borrow() {
+            Ok(b) => b,
+            Err(_) => panic!("SyncCell already borrowed"),
+        }
+    }
+}
+
+pub struct Guard<'a, T> {
+    cell: &'a SyncCell<T>,
+}
+
+unsafe impl<'a, T> Send for Guard<'a, T> where T: Send {}
+unsafe impl<'a, T> Sync for Guard<'a, T> where T: Sync {}
+
+impl<'a, T> Deref for Guard<'a, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.cell.data.get() }
+    }
+}
+
+impl<'a, T> DerefMut for Guard<'a, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { &mut *self.cell.data.get() }
+    }
+}
+
+impl<'a, T> Drop for Guard<'a, T> {
+    fn drop(&mut self) {
+        self.cell.borrowed.store(false, Ordering::Release);
+    }
+}
+
+#[derive(Debug)]
+pub struct BorrowMutError;
+
+impl fmt::Display for BorrowMutError {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        "SyncCell already borrowed".fmt(fmt)
+    }
+}
+
+impl Error for BorrowMutError {}


### PR DESCRIPTION
The VST3 and CLAP backends currently use `UnsafeCell` manually for mutable access to the `MainThreadState` and `ProcessState` structs, relying on the threading contracts of the plugin APIs for safety. This makes it easy to silently introduce UB due to e.g. unanticipated reentrant calls or misunderstandings of the plugin API contracts.

Introduce a `SyncCell` primitive, which can be thought of as a thread-safe version of `RefCell` (which only allows mutable borrowing) or as a version of `Mutex` that simply panics instead of blocking if two threads attempt to borrow its contents concurrently. Replace the manual usage of `UnsafeCell` in the VST3 and CLAP backends with `SyncCell`.