### PR TITLE
add editor_size method to Plugin trait

### DIFF
--- a/examples/gain-gui/src/lib.rs
+++ b/examples/gain-gui/src/lib.rs
@@ -121,6 +121,13 @@ impl Plugin for GainGui {
         true
     }
 
+    fn editor_size(&self) -> Size {
+        Size {
+            width: 256.0,
+            height: 256.0,
+        }
+    }
+
     fn editor(&mut self, host: EditorHost, parent: &ParentWindow) -> Self::Editor {
         GainGuiEditor::open(host, parent, &self.params).unwrap()
     }

--- a/examples/gain/src/lib.rs
+++ b/examples/gain/src/lib.rs
@@ -112,6 +112,13 @@ impl Plugin for Gain {
         false
     }
 
+    fn editor_size(&self) -> Size {
+        Size {
+            width: 0.0,
+            height: 0.0,
+        }
+    }
+
     fn editor(&mut self, _host: EditorHost, _parent: &ParentWindow) -> Self::Editor {
         NoEditor
     }

--- a/src/format/clap/gui.rs
+++ b/src/format/clap/gui.rs
@@ -133,19 +133,19 @@ impl<P: Plugin> Instance<P> {
         let instance = unsafe { &*(plugin as *const Self) };
         let main_thread_state = instance.main_thread_state.borrow();
 
-        if let Some(editor) = &main_thread_state.editor {
-            let size = editor.size();
+        let size = if let Some(editor) = &main_thread_state.editor {
+            editor.size()
+        } else {
+            main_thread_state.plugin.editor_size()
+        };
 
-            let width = unsafe { &mut *width };
-            *width = size.width.round() as u32;
+        let width = unsafe { &mut *width };
+        *width = size.width.round() as u32;
 
-            let height = unsafe { &mut *height };
-            *height = size.height.round() as u32;
+        let height = unsafe { &mut *height };
+        *height = size.height.round() as u32;
 
-            return true;
-        }
-
-        false
+        true
     }
 
     unsafe extern "C" fn gui_can_resize(_plugin: *const clap_plugin) -> bool {

--- a/src/format/clap/tests.rs
+++ b/src/format/clap/tests.rs
@@ -78,6 +78,12 @@ impl Plugin for TestPlugin {
     fn has_editor(&self) -> bool {
         false
     }
+    fn editor_size(&self) -> Size {
+        Size {
+            width: 0.0,
+            height: 0.0,
+        }
+    }
     fn editor(&mut self, _host: EditorHost, _parent: &ParentWindow) -> Self::Editor {
         TestEditor
     }

--- a/src/format/vst3/tests.rs
+++ b/src/format/vst3/tests.rs
@@ -85,6 +85,12 @@ impl Plugin for TestPlugin {
     fn has_editor(&self) -> bool {
         false
     }
+    fn editor_size(&self) -> Size {
+        Size {
+            width: 0.0,
+            height: 0.0,
+        }
+    }
     fn editor(&mut self, _host: EditorHost, _parent: &ParentWindow) -> Self::Editor {
         TestEditor
     }

--- a/src/format/vst3/view.rs
+++ b/src/format/vst3/view.rs
@@ -132,19 +132,19 @@ impl<P: Plugin> IPlugViewTrait for PlugView<P> {
 
         let main_thread_state = self.main_thread_state.borrow();
 
-        if let Some(editor) = &main_thread_state.editor {
-            let editor_size = editor.size();
+        let editor_size = if let Some(editor) = &main_thread_state.editor {
+            editor.size()
+        } else {
+            main_thread_state.plugin.editor_size()
+        };
 
-            let rect = unsafe { &mut *size };
-            rect.left = 0;
-            rect.top = 0;
-            rect.right = editor_size.width.round() as int32;
-            rect.bottom = editor_size.height.round() as int32;
+        let rect = unsafe { &mut *size };
+        rect.left = 0;
+        rect.top = 0;
+        rect.right = editor_size.width.round() as int32;
+        rect.bottom = editor_size.height.round() as int32;
 
-            return kResultOk;
-        }
-
-        kResultFalse
+        kResultOk
     }
 
     unsafe fn onSize(&self, _newSize: *mut ViewRect) -> tresult {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -2,7 +2,7 @@ use std::fmt::{self, Formatter};
 use std::io::{self, Read, Write};
 
 use crate::bus::{BusInfo, Layout};
-use crate::editor::{Editor, EditorHost, ParentWindow};
+use crate::editor::{Editor, EditorHost, ParentWindow, Size};
 use crate::host::Host;
 use crate::params::{ParamId, ParamInfo, ParamValue};
 use crate::process::{Config, Processor};
@@ -55,6 +55,7 @@ pub trait Plugin: Send + Sized + 'static {
     fn processor(&mut self, config: &Config) -> Self::Processor;
 
     fn has_editor(&self) -> bool;
+    fn editor_size(&self) -> Size;
     fn editor(&mut self, host: EditorHost, parent: &ParentWindow) -> Self::Editor;
 
     #[allow(unused_variables)]


### PR DESCRIPTION
In the VST3 and CLAP APIs, it is possible for a host to ask for the size of the editor GUI before providing a pointer to the parent window, whereas in Coupler, the `Editor` is not created until the parent window is available, and `Editor::size` can only be called after the `Editor` is created. In some hosts, this causes the host's parent window to have an incorrect initial size.

Add a `Plugin::editor_size` method which can be called if the host queries the size of the editor window before the `Editor` has been created.