### PR TITLE
protect Plugin::Editor with ThreadCell

### DIFF
--- a/src/format/clap/gui.rs
+++ b/src/format/clap/gui.rs
@@ -11,6 +11,7 @@ use super::instance::Instance;
 use crate::editor::{Editor, EditorHost, EditorHostInner, ParentWindow, RawParent};
 use crate::params::{ParamId, ParamValue};
 use crate::plugin::Plugin;
+use crate::sync::thread_cell::ThreadCell;
 use crate::sync::param_gestures::ParamGestures;
 
 struct ClapEditorHost {
@@ -204,7 +205,7 @@ impl<P: Plugin> Instance<P> {
         }));
         let parent = unsafe { ParentWindow::from_raw(raw_parent) };
         let editor = main_thread_state.plugin.editor(host, &parent);
-        main_thread_state.editor = Some(editor);
+        main_thread_state.editor = Some(ThreadCell::new(editor));
 
         true
     }

--- a/src/format/clap/instance.rs
+++ b/src/format/clap/instance.rs
@@ -19,7 +19,7 @@ use crate::plugin::Plugin;
 use crate::process::{Config, Processor};
 use crate::sync::param_gestures::{GestureStates, GestureUpdate, ParamGestures};
 use crate::sync::params::ParamValues;
-use crate::sync::sync_cell::SyncCell;
+use crate::sync::{sync_cell::SyncCell, thread_cell::ThreadCell};
 use crate::util::{DisplayParam, copy_cstring, slice_from_raw_parts_checked};
 
 fn port_type_from_format(format: &Format) -> &'static CStr {
@@ -49,7 +49,7 @@ pub struct MainThreadState<P: Plugin> {
     pub host_params: Option<NonNull<clap_host_params>>,
     pub layout_index: usize,
     pub plugin: P,
-    pub editor: Option<P::Editor>,
+    pub editor: Option<ThreadCell<P::Editor>>,
 }
 
 pub struct ProcessState<P: Plugin> {

--- a/src/format/vst3/component.rs
+++ b/src/format/vst3/component.rs
@@ -17,7 +17,7 @@ use crate::params::{ParamId, ParamInfo};
 use crate::plugin::Plugin;
 use crate::process::{Config, Processor};
 use crate::sync::params::ParamValues;
-use crate::sync::sync_cell::SyncCell;
+use crate::sync::{sync_cell::SyncCell, thread_cell::ThreadCell};
 use crate::util::{DisplayParam, slice_from_raw_parts_checked};
 
 fn format_to_speaker_arrangement(format: &Format) -> SpeakerArrangement {
@@ -39,7 +39,7 @@ pub struct MainThreadState<P: Plugin> {
     pub config: Config,
     pub plugin: P,
     pub handler: Option<ComPtr<IComponentHandler>>,
-    pub editor: Option<P::Editor>,
+    pub editor: Option<ThreadCell<P::Editor>>,
     pub frame: Option<ComPtr<IPlugFrame>>,
 }
 

--- a/src/format/vst3/view.rs
+++ b/src/format/vst3/view.rs
@@ -9,7 +9,7 @@ use super::component::MainThreadState;
 use crate::editor::{Editor, EditorHost, EditorHostInner, ParentWindow, RawParent};
 use crate::params::{ParamId, ParamValue};
 use crate::plugin::Plugin;
-use crate::sync::sync_cell::SyncCell;
+use crate::sync::{sync_cell::SyncCell, thread_cell::ThreadCell};
 
 pub struct Vst3EditorHost {
     pub handler: Option<ComPtr<IComponentHandler>>,
@@ -100,7 +100,7 @@ impl<P: Plugin> IPlugViewTrait for PlugView<P> {
         }));
         let parent = unsafe { ParentWindow::from_raw(raw_parent) };
         let editor = main_thread_state.plugin.editor(host, &parent);
-        main_thread_state.editor = Some(editor);
+        main_thread_state.editor = Some(ThreadCell::new(editor));
 
         kResultOk
     }

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -3,3 +3,4 @@ pub mod float;
 pub mod param_gestures;
 pub mod params;
 pub mod sync_cell;
+pub mod thread_cell;

--- a/src/sync/thread_cell.rs
+++ b/src/sync/thread_cell.rs
@@ -1,0 +1,57 @@
+use std::mem::ManuallyDrop;
+use std::ops::{Deref, DerefMut};
+use std::thread::{self, ThreadId};
+
+/// A wrapper that makes it possible to share `!Send` values between threads.
+///
+/// `ThreadCell` implements `Send` and `Sync` for all `T` while ensuring that its contents can only
+/// be accessed from the original thread on which it was created. Creating a `ThreadCell` on one
+/// thread and then dereferencing or dropping it on another thread will result in a panic.
+pub struct ThreadCell<T> {
+    thread: ThreadId,
+    data: ManuallyDrop<T>,
+}
+
+unsafe impl<T> Send for ThreadCell<T> {}
+unsafe impl<T> Sync for ThreadCell<T> {}
+
+impl<T> ThreadCell<T> {
+    pub fn new(data: T) -> ThreadCell<T> {
+        ThreadCell {
+            thread: thread::current().id(),
+            data: ManuallyDrop::new(data),
+        }
+    }
+
+    fn assert_thread(&self) {
+        if thread::current().id() != self.thread {
+            panic!("ThreadCell was created on a different thread");
+        }
+    }
+}
+
+impl<T> Deref for ThreadCell<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        self.assert_thread();
+
+        &*self.data
+    }
+}
+
+impl<T> DerefMut for ThreadCell<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.assert_thread();
+
+        &mut *self.data
+    }
+}
+
+impl<T> Drop for ThreadCell<T> {
+    fn drop(&mut self) {
+        self.assert_thread();
+
+        unsafe { ManuallyDrop::drop(&mut self.data) };
+    }
+}


### PR DESCRIPTION
The `Plugin::Editor` type is not required to implement `Send` or `Sync`, which means that each backend must ensure that it is only ever accessed from a single thread for the duration of its lifetime. Introduce a `ThreadCell` primitive which ensures that its contents are only ever accessed from a single thread and use it to ensure that the VST3 and CLAP backends respect this constraint with regard to the `Editor` type.