### PR TITLE
use string keys as unique parameter identifiers

### DIFF
--- a/coupler-derive/src/lib.rs
+++ b/coupler-derive/src/lib.rs
@@ -7,7 +7,7 @@ mod params;
 use enum_::expand_enum;
 use params::expand_params;
 
-#[proc_macro_derive(Params, attributes(param))]
+#[proc_macro_derive(Params, attributes(param, reserve))]
 pub fn derive_params(input: TokenStream) -> TokenStream {
     let input: DeriveInput = parse_macro_input!(input as DeriveInput);
 

--- a/coupler-derive/src/params.rs
+++ b/coupler-derive/src/params.rs
@@ -1,9 +1,9 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{Data, DeriveInput, Error, Expr, Field, Fields, LitInt, LitStr};
+use syn::{Data, DeriveInput, Error, Expr, Field, Fields, LitStr};
 
 struct ParamAttrs {
-    id: LitInt,
+    key: LitStr,
     name: LitStr,
     range: TokenStream,
     format: TokenStream,
@@ -12,7 +12,7 @@ struct ParamAttrs {
 fn parse_param(field: &Field) -> Result<Option<ParamAttrs>, Error> {
     let mut is_param = false;
 
-    let mut id = None;
+    let mut key = None;
     let mut name = None;
     let mut range = None;
     let mut format = None;
@@ -28,15 +28,15 @@ fn parse_param(field: &Field) -> Result<Option<ParamAttrs>, Error> {
             let ident = meta.path.get_ident().ok_or_else(|| {
                 Error::new_spanned(&meta.path, "expected this path to be an identifier")
             })?;
-            if ident == "id" {
-                if id.is_some() {
+            if ident == "key" {
+                if key.is_some() {
                     return Err(Error::new_spanned(
                         &meta.path,
-                        "duplicate param attribute `id`",
+                        "duplicate param attribute `key`",
                     ));
                 }
 
-                id = Some(meta.value()?.parse::<LitInt>()?);
+                key = Some(meta.value()?.parse::<LitStr>()?);
             } else if ident == "name" {
                 if name.is_some() {
                     return Err(Error::new_spanned(
@@ -79,10 +79,11 @@ fn parse_param(field: &Field) -> Result<Option<ParamAttrs>, Error> {
         return Ok(None);
     }
 
-    let id = if let Some(id) = id {
-        id
+    let key = if let Some(key) = key {
+        key
     } else {
-        return Err(Error::new_spanned(field, "missing `id` attribute"));
+        let ident = field.ident.as_ref().unwrap();
+        LitStr::new(&ident.to_string(), ident.span())
     };
 
     let name = if let Some(name) = name {
@@ -105,7 +106,7 @@ fn parse_param(field: &Field) -> Result<Option<ParamAttrs>, Error> {
     };
 
     Ok(Some(ParamAttrs {
-        id,
+        key,
         name,
         range,
         format,
@@ -155,16 +156,20 @@ pub fn expand_params(input: &DeriveInput) -> Result<TokenStream, Error> {
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
     let ident = &input.ident;
 
-    let param_info = fields.iter().map(|field| {
+    let param_keys = fields.iter().map(|field| {
+        let key = &field.param.key;
+
+        quote! { #key }
+    });
+
+    let param_infos = fields.iter().map(|field| {
         let ident = field.field.ident.as_ref().unwrap();
         let ty = &field.field.ty;
-        let id = &field.param.id;
         let name = &field.param.name;
         let range = &field.param.range;
 
         quote! {
             ::coupler::params::ParamInfo {
-                id: #id,
                 name: #name,
                 default: ::coupler::params::Range::<#ty>::encode(&(#range), &__default.#ident),
                 steps: ::coupler::params::Range::<#ty>::steps(&(#range)),
@@ -229,7 +234,7 @@ pub fn expand_params(input: &DeriveInput) -> Result<TokenStream, Error> {
                 let __default: #ident #ty_generics = ::std::default::Default::default();
 
                 __build
-                    #(.param(#param_info))*;
+                    #(.param(#param_keys, #param_infos))*;
             }
 
             fn set_param(&mut self, __index: ::std::primitive::usize, __value: ::std::primitive::f64) {

--- a/coupler-derive/src/params.rs
+++ b/coupler-derive/src/params.rs
@@ -1,9 +1,10 @@
 use proc_macro2::TokenStream;
 use quote::quote;
-use syn::{Data, DeriveInput, Error, Expr, Field, Fields, LitStr};
+use syn::{Data, DeriveInput, Error, Expr, Field, Fields, LitInt, LitStr};
 
 struct ParamAttrs {
     key: LitStr,
+    generation: Option<LitInt>,
     name: LitStr,
     range: TokenStream,
     format: TokenStream,
@@ -13,6 +14,7 @@ fn parse_param(field: &Field) -> Result<Option<ParamAttrs>, Error> {
     let mut is_param = false;
 
     let mut key = None;
+    let mut generation = None;
     let mut name = None;
     let mut range = None;
     let mut format = None;
@@ -37,6 +39,15 @@ fn parse_param(field: &Field) -> Result<Option<ParamAttrs>, Error> {
                 }
 
                 key = Some(meta.value()?.parse::<LitStr>()?);
+            } else if ident == "generation" {
+                if generation.is_some() {
+                    return Err(Error::new_spanned(
+                        &meta.path,
+                        "duplicate param attribute `generation`",
+                    ));
+                }
+
+                generation = Some(meta.value()?.parse::<LitInt>()?);
             } else if ident == "name" {
                 if name.is_some() {
                     return Err(Error::new_spanned(
@@ -107,6 +118,7 @@ fn parse_param(field: &Field) -> Result<Option<ParamAttrs>, Error> {
 
     Ok(Some(ParamAttrs {
         key,
+        generation,
         name,
         range,
         format,
@@ -159,7 +171,11 @@ pub fn expand_params(input: &DeriveInput) -> Result<TokenStream, Error> {
     let param_keys = fields.iter().map(|field| {
         let key = &field.param.key;
 
-        quote! { #key }
+        if let Some(generation) = &field.param.generation {
+            quote! { ::coupler::key::Key::new(#generation, #key) }
+        } else {
+            quote! { #key }
+        }
     });
 
     let param_infos = fields.iter().map(|field| {

--- a/coupler-derive/src/params.rs
+++ b/coupler-derive/src/params.rs
@@ -2,6 +2,64 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{Data, DeriveInput, Error, Expr, Field, Fields, LitInt, LitStr};
 
+struct Reserved {
+    key: LitStr,
+    generation: Option<LitInt>,
+}
+
+fn parse_reserved(input: &DeriveInput) -> Result<Vec<Reserved>, Error> {
+    let mut reserved = Vec::new();
+
+    for attr in &input.attrs {
+        if !attr.path().is_ident("reserve") {
+            continue;
+        }
+
+        let mut key = None;
+        let mut generation = None;
+
+        attr.parse_nested_meta(|meta| {
+            let ident = meta.path.get_ident().ok_or_else(|| {
+                Error::new_spanned(&meta.path, "expected this path to be an identifier")
+            })?;
+
+            if ident == "key" {
+                if key.is_some() {
+                    return Err(Error::new_spanned(&meta.path, "duplicate attribute `key`"));
+                }
+
+                key = Some(meta.value()?.parse::<LitStr>()?);
+            } else if ident == "generation" {
+                if generation.is_some() {
+                    return Err(Error::new_spanned(
+                        &meta.path,
+                        "duplicate attribute `generation`",
+                    ));
+                }
+
+                generation = Some(meta.value()?.parse::<LitInt>()?);
+            } else {
+                return Err(Error::new_spanned(
+                    &meta.path,
+                    format!("unknown param attribute `{}`", ident),
+                ));
+            }
+
+            Ok(())
+        })?;
+
+        let key = if let Some(key) = key {
+            key
+        } else {
+            return Err(Error::new_spanned(attr, "missing `key` attribute"));
+        };
+
+        reserved.push(Reserved { key, generation });
+    }
+
+    Ok(reserved)
+}
+
 struct ParamAttrs {
     key: LitStr,
     generation: Option<LitInt>,
@@ -30,6 +88,7 @@ fn parse_param(field: &Field) -> Result<Option<ParamAttrs>, Error> {
             let ident = meta.path.get_ident().ok_or_else(|| {
                 Error::new_spanned(&meta.path, "expected this path to be an identifier")
             })?;
+
             if ident == "key" {
                 if key.is_some() {
                     return Err(Error::new_spanned(
@@ -163,10 +222,21 @@ fn parse_fields(input: &DeriveInput) -> Result<Vec<ParamField<'_>>, Error> {
 }
 
 pub fn expand_params(input: &DeriveInput) -> Result<TokenStream, Error> {
+    let reserved = parse_reserved(input)?;
     let fields = parse_fields(input)?;
 
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
     let ident = &input.ident;
+
+    let reserved_keys = reserved.iter().map(|reserved| {
+        let key = &reserved.key;
+
+        if let Some(generation) = &reserved.generation {
+            quote! { ::coupler::key::Key::new(#generation, #key) }
+        } else {
+            quote! { #key }
+        }
+    });
 
     let param_keys = fields.iter().map(|field| {
         let key = &field.param.key;
@@ -250,6 +320,7 @@ pub fn expand_params(input: &DeriveInput) -> Result<TokenStream, Error> {
                 let __default: #ident #ty_generics = ::std::default::Default::default();
 
                 __build
+                    #(.reserve(#reserved_keys))*
                     #(.param(#param_keys, #param_infos))*;
             }
 

--- a/examples/gain-gui/src/lib.rs
+++ b/examples/gain-gui/src/lib.rs
@@ -24,7 +24,7 @@ use portlight::{
 
 #[derive(Params, Serialize, Deserialize, Clone)]
 struct GainGuiParams {
-    #[param(id = 0, name = "Gain", range = 0.0..1.0)]
+    #[param(name = "Gain", range = 0.0..1.0)]
     gain: f32,
 }
 

--- a/examples/gain/src/lib.rs
+++ b/examples/gain/src/lib.rs
@@ -15,7 +15,7 @@ use coupler::process::{Config, Processor};
 
 #[derive(Params, Serialize, Deserialize, Clone)]
 struct GainParams {
-    #[param(id = 0, name = "Gain", range = 0.0..1.0)]
+    #[param(name = "Gain", range = 0.0..1.0)]
     gain: f32,
 }
 

--- a/src/format/clap/instance.rs
+++ b/src/format/clap/instance.rs
@@ -92,6 +92,7 @@ pub struct Instance<P: Plugin> {
     pub bus_configs: Vec<OwnedBusConfig>,
     pub input_bus_map: Vec<usize>,
     pub output_bus_map: Vec<usize>,
+    pub param_ids: Vec<u32>,
     pub params: Vec<OwnedParamInfo>,
     pub param_map: HashMap<u32, usize>,
     // Processor -> plugin parameter changes
@@ -126,12 +127,12 @@ impl<P: Plugin> Instance<P> {
             }
         }
 
-        let params = collect_params(&plugin);
-        let param_count = params.len();
+        let (param_ids, params) = collect_params(&plugin);
+        let param_count = param_ids.len();
 
         let mut param_map = HashMap::new();
-        for (index, param) in params.iter().enumerate() {
-            param_map.insert(param.id, index);
+        for (index, &id) in param_ids.iter().enumerate() {
+            param_map.insert(id, index);
         }
 
         let has_editor = plugin.has_editor();
@@ -157,6 +158,7 @@ impl<P: Plugin> Instance<P> {
             input_bus_map,
             output_bus_map,
             params,
+            param_ids,
             param_map,
             plugin_params: ParamValues::with_count(param_count),
             processor_params: ParamValues::with_count(param_count),
@@ -220,6 +222,7 @@ impl<P: Plugin> Instance<P> {
         out_events: *const clap_output_events,
         time: u32,
     ) {
+        let param_id = self.param_ids[update.index];
         let param = &self.params[update.index];
 
         if update.begin_gesture {
@@ -231,7 +234,7 @@ impl<P: Plugin> Instance<P> {
                     type_: CLAP_EVENT_PARAM_GESTURE_BEGIN,
                     flags: CLAP_EVENT_IS_LIVE,
                 },
-                param_id: param.id,
+                param_id,
             };
 
             unsafe {
@@ -251,7 +254,7 @@ impl<P: Plugin> Instance<P> {
                     type_: CLAP_EVENT_PARAM_VALUE,
                     flags: CLAP_EVENT_IS_LIVE,
                 },
-                param_id: param.id,
+                param_id,
                 cookie: ptr::null_mut(),
                 note_id: -1,
                 port_index: -1,
@@ -277,7 +280,7 @@ impl<P: Plugin> Instance<P> {
                     type_: CLAP_EVENT_PARAM_GESTURE_END,
                     flags: CLAP_EVENT_IS_LIVE,
                 },
-                param_id: param.id,
+                param_id,
             };
 
             unsafe {
@@ -722,7 +725,7 @@ impl<P: Plugin> Instance<P> {
         if let Some(param) = instance.params.get(param_index as usize) {
             let param_info = unsafe { &mut *param_info };
 
-            param_info.id = param.id;
+            param_info.id = instance.param_ids[param_index as usize];
             param_info.flags = CLAP_PARAM_IS_AUTOMATABLE;
             param_info.cookie = ptr::null_mut();
             copy_cstring(&param.name, &mut param_info.name);

--- a/src/format/vst3/component.rs
+++ b/src/format/vst3/component.rs
@@ -58,7 +58,8 @@ pub struct Component<P: Plugin> {
     input_bus_map: Vec<usize>,
     output_bus_map: Vec<usize>,
     bus_config_set: HashSet<Vec<Layout>>,
-    params: Arc<Vec<OwnedParamInfo>>,
+    param_ids: Arc<Vec<u32>>,
+    params: Vec<OwnedParamInfo>,
     param_map: HashMap<u32, usize>,
     plugin_params: ParamValues,
     processor_params: ParamValues,
@@ -105,12 +106,12 @@ impl<P: Plugin> Component<P> {
 
         let scratch_buffers = ScratchBuffers::new(input_bus_map.len(), output_bus_map.len());
 
-        let params = collect_params(&plugin);
-        let param_count = params.len();
+        let (param_ids, params) = collect_params(&plugin);
+        let param_count = param_ids.len();
 
         let mut param_map = HashMap::new();
-        for (index, param) in params.iter().enumerate() {
-            param_map.insert(param.id, index);
+        for (index, &id) in param_ids.iter().enumerate() {
+            param_map.insert(id, index);
         }
 
         let has_editor = plugin.has_editor();
@@ -120,7 +121,8 @@ impl<P: Plugin> Component<P> {
             input_bus_map,
             output_bus_map,
             bus_config_set,
-            params: Arc::new(params),
+            param_ids: Arc::new(param_ids),
+            params: params,
             param_map,
             plugin_params: ParamValues::with_count(param_count),
             processor_params: ParamValues::with_count(param_count),
@@ -659,7 +661,7 @@ impl<P: Plugin> IEditControllerTrait for Component<P> {
         if let Some(param) = self.params.get(paramIndex as usize) {
             let info = unsafe { &mut *info };
 
-            info.id = param.id as ParamID;
+            info.id = self.param_ids[paramIndex as usize] as ParamID;
             copy_wstring(&param.name, &mut info.title);
             copy_wstring(&param.name, &mut info.shortTitle);
             copy_wstring("", &mut info.units);
@@ -776,7 +778,7 @@ impl<P: Plugin> IEditControllerTrait for Component<P> {
             return ptr::null_mut();
         }
 
-        let view = ComWrapper::new(PlugView::new(&self.params, &self.main_thread_state));
+        let view = ComWrapper::new(PlugView::new(&self.param_ids, &self.main_thread_state));
         view.to_com_ptr::<IPlugView>().unwrap().into_raw()
     }
 }

--- a/src/format/vst3/view.rs
+++ b/src/format/vst3/view.rs
@@ -7,21 +7,20 @@ use vst3::{Class, ComPtr, ComRef, Steinberg::*};
 
 use super::component::MainThreadState;
 use crate::editor::{Editor, EditorHost, EditorHostInner, ParentWindow, RawParent};
-use crate::params::OwnedParamInfo;
 use crate::plugin::Plugin;
 use crate::sync::{sync_cell::SyncCell, thread_cell::ThreadCell};
 use crate::util::RequireSendSync;
 
 struct Vst3EditorHost {
     handler: Option<ComPtr<IComponentHandler>>,
-    params: Arc<Vec<OwnedParamInfo>>,
+    param_ids: Arc<Vec<u32>>,
 }
 
 impl EditorHostInner for Vst3EditorHost {
     fn begin_gesture(&self, index: usize) {
         if let Some(handler) = &self.handler {
             unsafe {
-                handler.beginEdit(self.params[index].id);
+                handler.beginEdit(self.param_ids[index]);
             }
         }
     }
@@ -29,7 +28,7 @@ impl EditorHostInner for Vst3EditorHost {
     fn end_gesture(&self, index: usize) {
         if let Some(handler) = &self.handler {
             unsafe {
-                handler.endEdit(self.params[index].id);
+                handler.endEdit(self.param_ids[index]);
             }
         }
     }
@@ -37,14 +36,14 @@ impl EditorHostInner for Vst3EditorHost {
     fn set_param(&self, index: usize, value: f64) {
         if let Some(handler) = &self.handler {
             unsafe {
-                handler.performEdit(self.params[index].id, value);
+                handler.performEdit(self.param_ids[index], value);
             }
         }
     }
 }
 
 pub struct PlugView<P: Plugin> {
-    params: Arc<Vec<OwnedParamInfo>>,
+    param_ids: Arc<Vec<u32>>,
     main_thread_state: Arc<SyncCell<MainThreadState<P>>>,
 }
 
@@ -52,11 +51,11 @@ impl<P: Plugin> RequireSendSync for PlugView<P> {}
 
 impl<P: Plugin> PlugView<P> {
     pub fn new(
-        params: &Arc<Vec<OwnedParamInfo>>,
+        param_ids: &Arc<Vec<u32>>,
         main_thread_state: &Arc<SyncCell<MainThreadState<P>>>,
     ) -> PlugView<P> {
         PlugView {
-            params: params.clone(),
+            param_ids: param_ids.clone(),
             main_thread_state: main_thread_state.clone(),
         }
     }
@@ -106,7 +105,7 @@ impl<P: Plugin> IPlugViewTrait for PlugView<P> {
 
         let host = EditorHost::from_inner(Rc::new(Vst3EditorHost {
             handler: main_thread_state.handler.clone(),
-            params: self.params.clone(),
+            param_ids: self.param_ids.clone(),
         }));
         let parent = unsafe { ParentWindow::from_raw(raw_parent) };
         let editor = main_thread_state.plugin.editor(host, &parent);

--- a/src/key.rs
+++ b/src/key.rs
@@ -15,3 +15,65 @@ impl<'a> From<&'a str> for Key<'a> {
         Key::new(0, value)
     }
 }
+
+struct Entry {
+    generation: usize,
+    str: String,
+    index: Option<usize>,
+}
+
+impl Entry {
+    fn key(&self) -> Key<'_> {
+        Key {
+            generation: self.generation,
+            str: &self.str,
+        }
+    }
+}
+
+pub(crate) struct KeyList {
+    count: usize,
+    entries: Vec<Entry>,
+}
+
+impl KeyList {
+    pub fn new() -> Self {
+        KeyList {
+            count: 0,
+            entries: Vec::new(),
+        }
+    }
+
+    pub fn key<'k>(&mut self, key: impl Into<Key<'k>>) {
+        let key = key.into();
+        self.entries.push(Entry {
+            generation: key.generation,
+            str: key.str.to_string(),
+            index: Some(self.count),
+        });
+        self.count += 1;
+    }
+
+    pub fn reserve<'k>(&mut self, key: impl Into<Key<'k>>) {
+        let key = key.into();
+        self.entries.push(Entry {
+            generation: key.generation,
+            str: key.str.to_string(),
+            index: None,
+        });
+    }
+
+    pub fn into_ids(self) -> Vec<u32> {
+        let mut entries = self.entries;
+        entries.sort_by(|a, b| a.key().cmp(&b.key()));
+
+        let mut ids = vec![0; self.count];
+        for (id, entry) in entries.iter().enumerate() {
+            if let Some(index) = entry.index {
+                ids[index] = id.try_into().unwrap();
+            }
+        }
+
+        ids
+    }
+}

--- a/src/key.rs
+++ b/src/key.rs
@@ -77,3 +77,74 @@ impl KeyList {
         ids
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+    use std::iter;
+
+    use super::{Key, KeyList};
+
+    struct KeyMap {
+        keys: Vec<String>,
+        list: KeyList,
+    }
+
+    impl KeyMap {
+        fn new() -> KeyMap {
+            KeyMap {
+                keys: Vec::new(),
+                list: KeyList::new(),
+            }
+        }
+
+        pub fn key<'k>(mut self, key: impl Into<Key<'k>>) -> Self {
+            let key = key.into();
+            self.keys.push(key.str.to_string());
+            self.list.key(key);
+
+            self
+        }
+
+        pub fn reserve<'k>(mut self, key: impl Into<Key<'k>>) -> Self {
+            self.list.reserve(key);
+            self
+        }
+
+        fn build(self) -> HashMap<String, u32> {
+            let ids = self.list.into_ids();
+            iter::zip(self.keys, ids).collect()
+        }
+    }
+
+    #[test]
+    fn reorder_keys() {
+        let map1 = KeyMap::new().key("a").key("b").key("c").build();
+        let map2 = KeyMap::new().key("c").key("b").key("a").build();
+
+        // Reordering the list of keys should have no effect on the resulting IDs
+        assert_eq!(map1, map2);
+    }
+
+    #[test]
+    fn add_key() {
+        let map1 = KeyMap::new().key("a").key("b").key("c").build();
+        let map2 = KeyMap::new().key("a").key("b").key("c").key(Key::new(1, "aa")).build();
+
+        // Adding a new key should have no effect on the IDs for keys with lower generation numbers
+        for (key, id) in &map1 {
+            assert_eq!(id, &map2[key]);
+        }
+    }
+
+    #[test]
+    fn remove_key() {
+        let map1 = KeyMap::new().key("a").key("b").key("c").build();
+        let map2 = KeyMap::new().key("a").reserve("b").key("c").build();
+
+        // Removing and reserving a key should have no effect on the IDs for the remaining keys
+        for (key, id) in &map2 {
+            assert_eq!(id, &map1[key]);
+        }
+    }
+}

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,0 +1,17 @@
+#[derive(Copy, Clone, Debug, Eq, PartialEq, Ord, PartialOrd)]
+pub struct Key<'a> {
+    pub generation: usize,
+    pub str: &'a str,
+}
+
+impl<'a> Key<'a> {
+    pub fn new(generation: usize, str: &'a str) -> Key<'a> {
+        Key { generation, str }
+    }
+}
+
+impl<'a> From<&'a str> for Key<'a> {
+    fn from(value: &'a str) -> Key<'a> {
+        Key::new(0, value)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ pub mod editor;
 pub mod events;
 pub mod format;
 pub mod host;
+pub mod key;
 pub mod params;
 pub mod plugin;
 pub mod process;

--- a/src/params.rs
+++ b/src/params.rs
@@ -1,6 +1,7 @@
 use std::fmt::{self, Display};
 use std::str::FromStr;
 
+use crate::key::{Key, KeyList};
 use crate::plugin::Plugin;
 
 #[cfg(feature = "derive")]
@@ -13,41 +14,53 @@ pub use format::{DefaultFormat, Format};
 pub use range::{DefaultRange, Encode, Log, Range};
 
 pub struct ParamInfo<'a> {
-    pub id: u32,
     pub name: &'a str,
     pub default: f64,
     pub steps: Option<u32>,
 }
 
 pub trait BuildParams {
-    fn param(self, info: ParamInfo) -> Self;
+    fn param<'k>(self, key: impl Into<Key<'k>>, param: ParamInfo) -> Self;
+    fn reserve<'k>(self, key: impl Into<Key<'k>>) -> Self;
 }
 
 pub(crate) struct OwnedParamInfo {
-    pub id: u32,
     pub name: String,
     pub default: f64,
     pub steps: Option<u32>,
 }
 
-pub(crate) fn collect_params<P: Plugin>(plugin: &P) -> Vec<OwnedParamInfo> {
-    struct CollectParams<'a>(&'a mut Vec<OwnedParamInfo>);
+pub(crate) fn collect_params<P: Plugin>(plugin: &P) -> (Vec<u32>, Vec<OwnedParamInfo>) {
+    struct CollectParams<'a> {
+        keys: &'a mut KeyList,
+        params: &'a mut Vec<OwnedParamInfo>,
+    }
 
     impl<'a> BuildParams for CollectParams<'a> {
-        fn param(self, param: ParamInfo) -> Self {
-            self.0.push(OwnedParamInfo {
-                id: param.id,
+        fn param<'k>(self, key: impl Into<Key<'k>>, param: ParamInfo) -> Self {
+            self.keys.key(key);
+            self.params.push(OwnedParamInfo {
                 name: param.name.to_string(),
                 default: param.default,
                 steps: param.steps,
             });
             self
         }
+
+        fn reserve<'k>(self, key: impl Into<Key<'k>>) -> Self {
+            self.keys.reserve(key);
+            self
+        }
     }
 
+    let mut keys = KeyList::new();
     let mut params = Vec::new();
-    plugin.params(CollectParams(&mut params));
-    params
+    plugin.params(CollectParams {
+        keys: &mut keys,
+        params: &mut params,
+    });
+
+    (keys.into_ids(), params)
 }
 
 pub trait Params {


### PR DESCRIPTION
Implements the approach described in #3 (with the exception of nested parameter structs, which are left to future work). The mapping from string keys to unique `u32` identifiers is computed by sorting the list of (generation, string) pairs lexicographically (with reserved keys included in the list) and using each key's sort index as its corresponding `u32` identifier.